### PR TITLE
Fix event registration for Ctrl+C

### DIFF
--- a/Host-HttpListener.ps1
+++ b/Host-HttpListener.ps1
@@ -249,7 +249,7 @@ if (-not $AllowAllMethods) { Write-Host "Allowed methods: POST, PUT" -Foreground
 $stopRequested = $false
 
 # handle Ctrl+C gracefully
-$null = Register-ObjectEvent -SourceIdentifier ConsoleBreak -InputObject ([Console]::CancelKeyPress) -EventName CancelKeyPress -Action {
+$null = Register-ObjectEvent -SourceIdentifier ConsoleBreak -InputObject ([Console]) -EventName CancelKeyPress -Action {
     Write-Host "Ctrl+C detected - stopping listener..." -ForegroundColor Yellow
     $script:stopRequested = $true
     $event.Sender.Cancel = $true  # prevent abrupt kill; we'll exit loop


### PR DESCRIPTION
## Summary
- fix input object for Register-ObjectEvent so Ctrl+C handler works

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878a16db7c88333822d790c6a83af05