### PR TITLE
Move Get-ElasticSourceValue into shared helper

### DIFF
--- a/Scripts/Evaluate-OrchestraErrorsViaElastic/Evaluate-OrchestraErrorsViaElastic.ps1
+++ b/Scripts/Evaluate-OrchestraErrorsViaElastic/Evaluate-OrchestraErrorsViaElastic.ps1
@@ -168,50 +168,6 @@ if ($BusinessKeys) {
     }
 }
 
-function Get-ElasticSourceValue {
-    param(
-        [object]$Source,
-        [string]$FieldPath
-    )
-
-    if (-not $Source -or [string]::IsNullOrWhiteSpace($FieldPath)) {
-        return $null
-    }
-
-    $current = $Source
-    foreach ($segment in $FieldPath -split '\.') {
-        if ($null -eq $current) { return $null }
-
-        $prop = $current.PSObject.Properties[$segment]
-        if ($prop) {
-            $current = $prop.Value
-            continue
-        }
-
-        if ($current -is [System.Collections.IDictionary]) {
-            if ($current.Contains($segment)) {
-                $current = $current[$segment]
-                continue
-            }
-
-            $foundKey = $false
-            foreach ($key in $current.Keys) {
-                if ($key -eq $segment) {
-                    $current = $current[$key]
-                    $foundKey = $true
-                    break
-                }
-            }
-
-            if ($foundKey) { continue }
-        }
-
-        return $null
-    }
-
-    return $current
-}
-
 function Get-SafeErrorFragment {
     param(
         [string]$ErrorText


### PR DESCRIPTION
## Summary
- add `Get-ElasticSourceValue` to `Scripts/Common/ElasticSearchHelpers.ps1` so nested `_source` lookups are reusable
- remove the local `Get-ElasticSourceValue` definition from `Evaluate-OrchestraErrorsViaElastic.ps1` now that it comes from the shared helper

## Testing
- `pwsh -NoLogo -NoProfile -Command ". './Scripts/Common/ElasticSearchHelpers.ps1'; \$obj = [pscustomobject]@{ BK = [pscustomobject]@{ _STATUS_TEXT = 'value'; nested = @{ inner = 42 } } }; Get-ElasticSourceValue -Source \$obj -FieldPath 'BK._STATUS_TEXT'; Get-ElasticSourceValue -Source \$obj -FieldPath 'BK.nested.inner'; Get-ElasticSourceValue -Source \$obj -FieldPath 'BK.missing'"`


------
https://chatgpt.com/codex/tasks/task_b_68c940e2c4f88333b6782d09a5a1bdff