### PR TITLE
Handle DateTime parsing in Get-PatientInfo

### DIFF
--- a/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
+++ b/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
@@ -162,7 +162,17 @@ function Convert-ToTimestamp {
     if ([string]::IsNullOrWhiteSpace($value)) { return $null }
 
     $parsed = $null
-    if ([datetime]::TryParse($value, [ref]$parsed)) { return $parsed }
+    if ($value -is [System.DateTimeOffset]) { return $value.UtcDateTime }
+
+    $stringValue = $value.ToString()
+    if ([datetime]::TryParse(
+        $stringValue,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::AssumeUniversal,
+        [ref]$parsed
+    )) {
+        return $parsed
+    }
     return $null
 }
 


### PR DESCRIPTION
## Summary
- ensure Get-PatientInfo converts DateTimeOffset values and parses strings using invariant culture to avoid TryParse overload errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a7d39f6d08333b89190f0bf0997c5)