### PR TITLE
Exclude dropped SUBFL records from Get-PatientInfo

### DIFF
--- a/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
+++ b/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
@@ -260,7 +260,10 @@ $baseMust = @(
     ); minimum_should_match = 1 } }
 )
 
-$mustNot = @(@{ term = @{ 'WorkflowPattern' = 'REQ_RESP' } })
+$mustNot = @(
+    @{ term = @{ 'WorkflowPattern' = 'REQ_RESP' } },
+    @{ term = @{ 'BK.SUBFL_drop' = $true } }
+)
 
 if ($StartDate -or $EndDate) {
     $rangeEntry = @{ range = @{ ($ElasticTimeField) = @{} } }


### PR DESCRIPTION
## Summary
- update the Get-PatientInfo base query to exclude documents marked with BK.SUBFL_drop

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a8ec6c25c83338e783b07910fdfe4)