### PR TITLE
Allow variable channel roots in scenario validation

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -50,10 +50,10 @@ Scheduling shorthand (used in naming conventions):
 
 Channel files are XML documents named `Channel_*` with no extension. XML root names vary by channel type.
 
-Validation currently reads HTTP outbound channel nodes:
+Validation reads channel fields from the document root regardless of the specific channel type:
 
-- `/emds.epi.impl.adapter.http.outbound.HttpOutboundGeneralChannel/name`: Channel name.
-- `/emds.epi.impl.adapter.http.outbound.HttpOutboundGeneralChannel/numberOfInstances`: Concurrency count.
+- `/*/name`: Channel name.
+- `/*/numberOfInstances`: Concurrency count.
 
 A channel is considered non-concurrent when `numberOfInstances` is `1`.
 

--- a/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
@@ -176,8 +176,8 @@ foreach ($file in $files) {
     }
 
     if ($file.Name -like $channelPattern) {
-        $channelName = Get-NodeValue -XmlDocument $xmlContent -XPath '/emds.epi.impl.adapter.http.outbound.HttpOutboundGeneralChannel/name'
-        $numberOfInstances = Get-NodeValue -XmlDocument $xmlContent -XPath '/emds.epi.impl.adapter.http.outbound.HttpOutboundGeneralChannel/numberOfInstances'
+        $channelName = Get-NodeValue -XmlDocument $xmlContent -XPath '/*[1]/name'
+        $numberOfInstances = Get-NodeValue -XmlDocument $xmlContent -XPath '/*[1]/numberOfInstances'
 
         if ($numberOfInstances -eq '1') {
             $scenarioResults[$scenarioInfo.Name].Channels += [PSCustomObject]@{


### PR DESCRIPTION
### Motivation
- Make channel concurrency and name extraction resilient to varying XML root element names in `Channel_*` files so the validation works across different channel types.

### Description
- Update `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` to read channel fields using `/*[1]/name` and `/*[1]/numberOfInstances` and update `ScenarioInfo.md` to document `/*/name` and `/*/numberOfInstances` as the channel-field XPaths.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697caf6fc76c8333a68fef4da7f20826)