### PR TITLE
Validate-Scenarios: support description-based exceptions, naming-code output, and ShowExceptions switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-OrchestraErrorsViaElastic.ps1** - Aggregates failed Orchestra scenarios from Elasticsearch and optionally exports normalized error XML.
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
-- **Validate-Scenarios.ps1** - Validates scenario configuration files and reports findings by scenario.
+- **Validate-Scenarios.ps1** - Validates scenario configuration files, reporting naming-convention codes and optional description-based exceptions.
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 
 ## Shared utilities

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -23,6 +23,8 @@ Process model files are XML documents named `ProcessModell_*` (no extension).
 
 XML root name: `ProcessModel`.
 
+Each configuration XML supports a `description` element directly below the root. Validation can read exception codes from this description to allow deviations from the default rules. Default values typically omit explicit description codes but are still valid.
+
 Validation reads the following fields:
 
 - `/ProcessModel/name`: Process model name.
@@ -50,6 +52,8 @@ Scheduling shorthand (used in naming conventions):
 
 Channel files are XML documents named `Channel_*` with no extension. XML root names vary by channel type.
 
+Each channel XML supports a `description` element directly below the root. Validation can read exception codes from this description to allow deviations from the default rules.
+
 Validation reads channel fields from the document root regardless of the specific channel type:
 
 - `/*/name`: Channel name.
@@ -60,6 +64,8 @@ A channel is considered non-concurrent when `numberOfInstances` is `1`.
 ## Message mapping files (`MessageMapping_*`)
 
 XML root name: `emds.mapping.proc.MappingScript`.
+
+Each mapping XML supports a `description` element directly below the root. Validation can read exception codes from this description to allow deviations from the default rules.
 
 Validation reads:
 
@@ -102,3 +108,18 @@ Mappings are flagged when `parallelExecution` is not `true`.
   - **ST** Resource usage strategy
     - `p`: Parallel execution
     - `s`: Sequential execution
+
+## Description-based exceptions
+
+Validation reads optional codes embedded in the `description` text (for example: `PM:v; RS:a; SC:p75`). Codes can appear anywhere in the description and multiple codes can be listed. Only codes that align to validation checks are considered; unsupported codes such as `SC` are ignored.
+
+Supported exception codes:
+
+- **PM** Process Mode (`v`, `vr`, `p`)
+- **RS** Redeployment Strategy (`a`, `r`)
+- **MR** Manual Restart (`e`, `d`)
+- **SI** Input Signal (`p`, `t`)
+- **ST** Resource usage strategy (`p`, `s`) for channels and mappings
+- **BK** Business key maximum (`#`)
+
+When the script finds a non-default configuration that matches an exception code, it suppresses the entry by default and can optionally list it with an "exception configured" note.


### PR DESCRIPTION
### Motivation
- Add support for the new naming-convention style for error messages so validations can report compact codes (e.g. `PM:v`, `RS:a`, `BK:3`) instead of free-text messages.
- Allow scenarios to declare exceptions to validation rules inside the `description` element of their XML files so known deviations can be suppressed or optionally shown.
- Provide an option to surface entries that are suppressed by exception rules for auditing and review.

### Description
- Implemented parsing of `description` text with `Get-DescriptionTokens`, `Test-ExceptionMatch`, and `Get-BusinessKeyExceptionLimit` to extract two-letter codes and values (e.g. `PM:v`, `BK:8`).
- Reworked ProcessModel, Channel, and Mapping checks to emit naming-convention codes (`PM`, `RS`, `MR`, `SI`, `ST`, `BK`) and to consult description-based exception tokens; when an exception token matches the non-default value the issue is suppressed unless `-ShowExceptions` is passed, in which case it is listed with "(exception configured)".
- Added new `-ShowExceptions` switch parameter to `Validate-Scenarios.ps1` and updated business-key logic to accept `BK:#` overrides (largest numeric BK value wins when multiple present).
- Updated `ScenarioInfo.md` with documentation for description-based exceptions and updated `README.md` script entry to mention naming-code output and description-driven exceptions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698078a7e0ec8333ac23782d6582c6b3)