### PR TITLE
Validate-Scenarios: add category filtering and colored verbose issue output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-OrchestraErrorsViaElastic.ps1** - Aggregates failed Orchestra scenarios from Elasticsearch and optionally exports normalized error XML.
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
-- **Validate-Scenarios.ps1** - Validates scenario configuration files, reporting naming-convention codes and optional description-based exceptions.
+- **Validate-Scenarios.ps1** - Validates scenario configuration files, with optional filtering by validation category and description-based exceptions.
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 
 ## Shared utilities

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This file summarizes the Orchestra scenario folder layout and highlights the configuration values that the `Validate-Scenarios` script inspects. Scenario folders are organized by scenario name and contain XML configuration artifacts without file extensions.
+This file summarizes the Orchestra scenario folder layout and highlights the configuration values that the `Validate-Scenarios` script inspects. Scenario folders are organized by scenario name and contain XML configuration artifacts without file extensions. The script can optionally filter validations to specific category codes (for example: ST, PM).
 
 ## Scenario root layout
 


### PR DESCRIPTION
### Motivation
- Allow running the scenario validation while checking only a subset of validation categories (for example: `ST`, `PM`) and make reported issues easier to scan by showing the short shorthand in color with a longer, default-color explanation.

### Description
- Added a new `ErrorCategories` parameter to `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` that accepts a list of category tokens and restricts which validation checks run (defaults to all categories if omitted).
- Reworked issue representation from plain strings to PSCustomObjects with `Short` and `Message` fields and added `New-ValidationIssue` and `Write-IssueLine` helpers to emit the short code in color (`$issueColor`) and the verbose message in the default color.
- Added `Test-CategoryEnabled` helper and a category set parser to normalize comma/semicolon-separated input and drive per-check gating for `PM`, `RS`, `MR`, `SI`, `BK`, and `ST` checks.
- Updated documentation lines in `README.md` and `ScenarioInfo.md` to mention the new category filtering option for `Validate-Scenarios.ps1`.

### Testing
- No automated tests were executed as part of this change (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69807b72ad548333ad7ad530a2dd1c34)