### PR TITLE
Clarify Validate-Scenarios default naming expectations and add long-form key names

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -109,6 +109,17 @@ Mappings are flagged when `parallelExecution` is not `true`.
     - `p`: Parallel execution
     - `s`: Sequential execution
 
+Default naming expectations (documented even when not validated):
+
+- **PM**: `vr` (volatile with recovery)
+- **RS**: `r` (restart after redeployment)
+- **MR**: `e` (manual restart enabled)
+- **SC**: `p` (parallel unbounded scheduling)
+- **BK**: `#` (up to the script-configured maximum)
+- **SI**: `p` (persistent subscription)
+- **CH/ST**: `p` (parallel execution)
+- **MM/ST**: `p` (parallel execution)
+
 ## Description-based exceptions
 
 Validation reads optional codes embedded in the `description` text (for example: `PM:v; RS:a; SC:p75`). Codes can appear anywhere in the description and multiple codes can be listed. Only codes that align to validation checks are considered; unsupported codes such as `SC` are ignored.

--- a/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
@@ -12,6 +12,16 @@
     include exception codes (for example: "PM:v; RS:a; SC:p75") to allow deviations
     from the default validation rules.
 
+.NOTES
+    Default naming expectations (documented for reference even if not validated):
+    - PM (Process Mode): vr (volatile with recovery)
+    - RS (Redeployment Strategy): r (restart on redeploy)
+    - MR (Manual Restart): e (manual restart enabled)
+    - SC (Scheduling): p (parallel unbounded scheduling)
+    - BK (Business Keys): MaxBusinessKeyCount (maximum allowed business keys)
+    - SI (Input Signal): p (persistent subscription)
+    - ST (Resource usage strategy): p (parallel execution) for channels and mappings
+
 .PARAMETER Path
     Root folder that contains scenario subfolders. Defaults to the current directory.
 


### PR DESCRIPTION
### Motivation
- Improve clarity of the default naming expectations used by the validation script so readers can quickly map short codes to their meanings.
- Keep the centralized documentation in sync by recording the same defaults in `ScenarioInfo.md` and the script notes in `Scripts/Validate-Scenarios/Validate-Scenarios.ps1`.

### Description
- Updated `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` `.NOTES` block to include long-form names for keys and explicit default expectations for `PM`, `RS`, `MR`, `SC`, `BK`, `SI`, and `ST`.
- Updated `ScenarioInfo.md` to add the same default naming expectations and to clarify `CH/ST` and `MM/ST` defaults for channels and message mappings.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698090331bf08333929b995c43d6127b)