### PR TITLE
Allow blank output lines in Validate-Scenarios

### DIFF
--- a/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
@@ -332,6 +332,7 @@ $outputLines = New-Object System.Collections.Generic.List[string]
 function Add-OutputLine {
     param (
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string]$Line
     )
 


### PR DESCRIPTION
### Motivation
- Fix a `ParameterBindingValidationException` when `Add-OutputLine` was invoked with an intentional empty string, which previously caused the `Validate-Scenarios` script to fail.

### Description
- Added the `[AllowEmptyString()]` attribute to the `-Line` parameter of `Add-OutputLine` in `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` so empty strings are accepted and can be used for intentional blank lines.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698094d572d0833383971d12d2dde392)