### PR TITLE
Skip non-XML PSC entries in scenario validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-OrchestraErrorsViaElastic.ps1** - Aggregates failed Orchestra scenarios from Elasticsearch and optionally exports normalized error XML.
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
-- **Validate-Scenarios.ps1** - Validates scenario configuration files or PSC archives, with optional validation-category filtering and optional text report output.
+- **Validate-Scenarios.ps1** - Validates scenario configuration files or PSC archives, with optional validation-category filtering and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 
 ## Shared utilities

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -15,7 +15,7 @@ This file summarizes the Orchestra scenario folder layout and highlights the con
 
 ## PSC file
 
-A `.psc` file is a zipped scenario folder (the folder contents, not the folder itself). When requested, `Validate-Scenarios` opens `.psc` archives and validates the same `ProcessModell_*`, `Channel_*`, and `MessageMapping_*` entries contained inside.
+A `.psc` file is a zipped scenario folder (the folder contents, not the folder itself). When requested, `Validate-Scenarios` opens `.psc` archives and validates the same `ProcessModell_*`, `Channel_*`, and `MessageMapping_*` entries contained inside, skipping entries that include file extensions (such as `.prop`).
 
 ## Process model files (`ProcessModell_*`)
 

--- a/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
@@ -573,6 +573,10 @@ foreach ($pscFile in $pscFiles) {
                 continue
             }
 
+            if (-not [string]::IsNullOrWhiteSpace([System.IO.Path]::GetExtension($entryName))) {
+                continue
+            }
+
             if (-not ($entryName -like $processModelPattern -or $entryName -like $channelPattern -or $entryName -like $mappingPattern)) {
                 continue
             }


### PR DESCRIPTION
### Motivation
- Avoid XML parse warnings and errors when `Validate-Scenarios.ps1` inspects `.psc` archives by ignoring archive entries that are not XML artifacts (for example `.prop` files).
- Keep repository documentation in sync with runtime behavior so users understand which PSC entries are validated.

### Description
- Update `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` to skip archive entries that include a file extension by checking `([System.IO.Path]::GetExtension($entryName))` before attempting XML parsing.
- Update `README.md` to note that `Validate-Scenarios.ps1` ignores non-XML PSC entries. 
- Update `ScenarioInfo.md` to document that PSC entries with extensions (such as `.prop`) are skipped during validation.
- Changes touch three files: `Scripts/Validate-Scenarios/Validate-Scenarios.ps1`, `README.md`, and `ScenarioInfo.md`.

### Testing
- No automated tests were executed as part of this change.
- Commit includes the code and documentation updates and was recorded successfully (`3 files changed, 6 insertions(+), 2 deletions(-)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698095e2afa88333bf703e567c8516ec)