### PR TITLE
Allow PSC base-name matching in Validate-Scenarios filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-OrchestraErrorsViaElastic.ps1** - Aggregates failed Orchestra scenarios from Elasticsearch and optionally exports normalized error XML.
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
-- **Validate-Scenarios.ps1** - Validates scenario configuration files or PSC archives, with optional validation-category filtering and optional text report output (ignores non-XML PSC entries).
+- **Validate-Scenarios.ps1** - Validates scenario configuration files or PSC archives, with optional validation-category filtering, wildcard filtering that matches folder names or PSC base names, and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 
 ## Shared utilities

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This file summarizes the Orchestra scenario folder layout and highlights the configuration values that the `Validate-Scenarios` script inspects. Scenario folders are organized by scenario name and contain XML configuration artifacts without file extensions. The script can optionally filter validations to specific category codes (for example: ST, PM), apply wildcard filters to folders or files, and inspect `.psc` archives when requested.
+This file summarizes the Orchestra scenario folder layout and highlights the configuration values that the `Validate-Scenarios` script inspects. Scenario folders are organized by scenario name and contain XML configuration artifacts without file extensions. The script can optionally filter validations to specific category codes (for example: ST, PM), apply wildcard filters to folders or PSC base names, and inspect `.psc` archives when requested.
 
 ## Scenario root layout
 

--- a/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
@@ -178,6 +178,14 @@ function Test-PathMatchesFilter {
     }
 
     $segments = $Path -split '[\\/]' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $segmentCandidates = New-Object System.Collections.Generic.List[string]
+    foreach ($segment in $segments) {
+        $segmentCandidates.Add($segment)
+        $baseName = [System.IO.Path]::GetFileNameWithoutExtension($segment)
+        if ($baseName -and $baseName -ne $segment) {
+            $segmentCandidates.Add($baseName)
+        }
+    }
     foreach ($pattern in $Filters) {
         if ([string]::IsNullOrWhiteSpace($pattern)) {
             continue
@@ -187,7 +195,7 @@ function Test-PathMatchesFilter {
             return $true
         }
 
-        foreach ($segment in $segments) {
+        foreach ($segment in $segmentCandidates) {
             if ($segment -like $pattern) {
                 return $true
             }


### PR DESCRIPTION
### Motivation
- Ensure that `-IncludePsc` workflows can be filtered by PSC archive base names or folder names without requiring `-Filter *.psc`, aligning filter behavior with user expectations.
- Update documentation to clearly describe the wildcard filtering behavior for PSC archives.

### Description
- Enhance `Test-PathMatchesFilter` in `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` to build a `segmentCandidates` list that includes each path segment and its file base name (via `GetFileNameWithoutExtension`) so filters match PSC base names as well as folder names.
- Adjust the segment iteration to test patterns against `segmentCandidates` instead of raw path segments in `Test-PathMatchesFilter`.
- Update `README.md` and `ScenarioInfo.md` to document that wildcard filters match folder names or PSC base names and to note the improved behavior of `Validate-Scenarios.ps1`.

### Testing
- No automated tests were executed for this change.
- Changes were implemented and committed for the three files `Scripts/Validate-Scenarios/Validate-Scenarios.ps1`, `README.md`, and `ScenarioInfo.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698097c4fc3c8333975e1abff8d3bc56)