### PR TITLE
Add Mode parameter to Validate-Scenarios (Folder|PSC) and update filtering behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-OrchestraErrorsViaElastic.ps1** - Aggregates failed Orchestra scenarios from Elasticsearch and optionally exports normalized error XML.
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
-- **Validate-Scenarios.ps1** - Validates scenario configuration files or PSC archives, with optional validation-category filtering, wildcard filtering that matches folder names or PSC base names, and optional text report output (ignores non-XML PSC entries).
+- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives, with optional mode selection, validation-category filtering, folder/PSC name filtering, and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 
 ## Shared utilities

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This file summarizes the Orchestra scenario folder layout and highlights the configuration values that the `Validate-Scenarios` script inspects. Scenario folders are organized by scenario name and contain XML configuration artifacts without file extensions. The script can optionally filter validations to specific category codes (for example: ST, PM), apply wildcard filters to folders or PSC base names, and inspect `.psc` archives when requested.
+This file summarizes the Orchestra scenario folder layout and highlights the configuration values that the `Validate-Scenarios` script inspects. Scenario folders are organized by scenario name and contain XML configuration artifacts without file extensions. The script can optionally filter validations to specific category codes (for example: ST, PM), filter scenario folder names or PSC file names, and switch between folder and PSC validation modes.
 
 ## Scenario root layout
 
@@ -15,7 +15,7 @@ This file summarizes the Orchestra scenario folder layout and highlights the con
 
 ## PSC file
 
-A `.psc` file is a zipped scenario folder (the folder contents, not the folder itself). When requested, `Validate-Scenarios` opens `.psc` archives and validates the same `ProcessModell_*`, `Channel_*`, and `MessageMapping_*` entries contained inside, skipping entries that include file extensions (such as `.prop`).
+A `.psc` file is a zipped scenario folder (the folder contents, not the folder itself). When `Validate-Scenarios` runs in PSC mode (or when PSC inspection is enabled in folder mode), it opens `.psc` archives and validates the same `ProcessModell_*`, `Channel_*`, and `MessageMapping_*` entries contained inside, skipping entries that include file extensions (such as `.prop`).
 
 ## Process model files (`ProcessModell_*`)
 


### PR DESCRIPTION
### Motivation

- Allow callers to explicitly choose whether to validate scenario folders or only PSC archives, and adjust filtering semantics accordingly.
- Make PSC handling and defaults clearer and avoid scanning unrelated files when PSC mode is requested.

### Description

- Added a new `-Mode` parameter with `ValidateSet('Folder','PSC')` and default `Folder` to `Scripts/Validate-Scenarios/Validate-Scenarios.ps1`.
- Changed `Filter` semantics so it applies to scenario folder names in Folder mode and to PSC file names in PSC mode, and introduced an `effectivePscFilters` fallback of `*.psc` when running in PSC mode with no explicit filter.
- Replaced `Test-PathMatchesFilter` with `Test-NameMatchesFilter` to evaluate folder or file base names against the provided filters, and updated folder-selection and PSC-selection logic to respect the new mode and filter behavior; `IncludePsc` now only affects folder-mode behavior.
- Updated docs in `README.md` and `ScenarioInfo.md` to document the new mode option and the revised filtering behavior.

### Testing

- No automated tests were run as part of this change.
- Basic repository checks (file updates and commit) were performed locally; no unit or integration tests executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69809908ec348333af33deeeef40b72d)