### PR TITLE
Add Timespan parameter as alternative to EndDate for date-range scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 
 - **SubflElasticInfo.md** - Overview of Subscription Flow (SUBFL) terminology plus how SUBFL scenarios log to Elasticsearch, including the specific fields and filters leveraged by the SUBFL-related scripts in this repository.
 - **ScenarioInfo.md** - Reference for Orchestra scenario folder structure, including expected file naming patterns and scenario-related configuration notes drawn from the scripts.
+
+## Shared date-range behavior
+
+Scripts that expose `StartDate`/`EndDate` now also support `Timespan` as an alternative to `EndDate`. `Timespan` accepts either a number (minutes) or a PowerShell `TimeSpan` value. When `EndDate` and `Timespan` are both omitted, a default window of 15 minutes is used from `StartDate`.
+

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -134,3 +134,8 @@ Supported exception codes:
 - **BK** Business key maximum (`#`)
 
 When the script finds a non-default configuration that matches an exception code, it suppresses the entry by default and can optionally list it with an "exception configured" note.
+
+## Script parameter conventions
+- Repository scripts that expose both `StartDate` and `EndDate` can also accept `Timespan` as an alternative end-bound.
+- `Timespan` accepts numeric minute values and PowerShell `TimeSpan` values.
+- If neither `EndDate` nor `Timespan` is supplied, a default 15-minute window is used from `StartDate`.

--- a/Scripts/Evaluate-AdmKavideErrors/Evaluate-AdmKavideErrors.ps1
+++ b/Scripts/Evaluate-AdmKavideErrors/Evaluate-AdmKavideErrors.ps1
@@ -28,11 +28,16 @@
 
 .PARAMETER StartDate
     Inclusive start date for @timestamp filtering (local time). Defaults to the
-    start of the current day if omitted. If EndDate is not supplied, it is set
-    to the end of the StartDate day.
+    start of the current day if omitted. If neither EndDate nor Timespan is
+    supplied, EndDate defaults to StartDate plus 15 minutes.
 
 .PARAMETER EndDate
     Inclusive end date for @timestamp filtering (local time).
+
+.PARAMETER Timespan
+    Optional duration used to derive EndDate from StartDate. Accepts either a
+    TimeSpan value (for example `00:30:00`) or a numeric value interpreted as
+    minutes. Cannot be used together with EndDate.
 
 .PARAMETER Environment
     Environment value to match (production, staging, testing). Defaults to
@@ -71,6 +76,9 @@ param(
     [datetime]$EndDate,
 
     [Parameter(Mandatory=$false)]
+    [object]$Timespan,
+
+    [Parameter(Mandatory=$false)]
     [ValidateSet('production','staging','testing')]
     [string]$Environment = 'production',
 
@@ -100,13 +108,48 @@ if (-not (Test-Path -Path $sharedHelpersPath)) {
 }
 . $sharedHelpersPath
 
+function Resolve-EffectiveTimespan {
+    param(
+        [object]$Value,
+        [int]$DefaultMinutes = 15
+    )
+
+    if ($null -eq $Value -or [string]::IsNullOrWhiteSpace("$Value")) {
+        return [timespan]::FromMinutes($DefaultMinutes)
+    }
+
+    if ($Value -is [timespan]) { return $Value }
+    if ($Value -is [byte] -or $Value -is [int16] -or $Value -is [int32] -or $Value -is [int64] -or $Value -is [single] -or $Value -is [double] -or $Value -is [decimal]) {
+        return [timespan]::FromMinutes([double]$Value)
+    }
+
+    $minutes = 0.0
+    $textValue = "$Value".Trim()
+    if ([double]::TryParse($textValue, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$minutes)) {
+        return [timespan]::FromMinutes($minutes)
+    }
+
+    $parsedTimeSpan = [timespan]::Zero
+    if ([timespan]::TryParse($textValue, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsedTimeSpan)) {
+        return $parsedTimeSpan
+    }
+
+    throw "Invalid Timespan '$Value'. Provide a number (minutes) or a TimeSpan value."
+}
+
 $includeEnd = $PSBoundParameters.ContainsKey('EndDate')
+if ($includeEnd -and $PSBoundParameters.ContainsKey('Timespan')) {
+    throw 'Specify either EndDate or Timespan, not both.'
+}
+
 if (-not $PSBoundParameters.ContainsKey('StartDate')) {
     $StartDate = [datetime]::Today
-    if (-not $includeEnd) {
-        $EndDate = $StartDate.Date.AddDays(1).AddMilliseconds(-1)
-        $includeEnd = $true
-    }
+}
+
+if (-not $includeEnd) {
+    $effectiveTimespan = Resolve-EffectiveTimespan -Value $Timespan
+    $EndDate = $StartDate.Add($effectiveTimespan)
+    $includeEnd = $true
 }
 
 $headers = @{}

--- a/Scripts/Process-MissingADM/Process-MissingADM.ps1
+++ b/Scripts/Process-MissingADM/Process-MissingADM.ps1
@@ -13,11 +13,16 @@
 
 .PARAMETER StartDate
     Inclusive start date used to filter STO_STAMP (DB) and the time field in Elasticsearch.
-    If omitted, defaults to the current day start (00:00:00) and EndDate defaults
-    to the end of the same day (23:59:59.999).
+    If omitted, defaults to the current day start (00:00:00). If neither EndDate
+    nor Timespan is supplied, EndDate defaults to StartDate plus 15 minutes.
 
 .PARAMETER EndDate
     Optional inclusive end date used to filter STO_STAMP (DB) and the time field in Elasticsearch.
+
+.PARAMETER Timespan
+    Optional duration used to derive EndDate from StartDate. Accepts either a
+    TimeSpan value (for example `00:30:00`) or a numeric value interpreted as
+    minutes. Cannot be used together with EndDate.
 
 .PARAMETER DatabaseServerConnection
     SQL Server host and port in the format 'host,port'. Defaults to
@@ -63,6 +68,9 @@ param(
     [datetime]$EndDate,
 
     [Parameter(Mandatory=$false)]
+    [object]$Timespan,
+
+    [Parameter(Mandatory=$false)]
     [string]$DatabaseServerConnection = 'idesql.wienkav.at,1433',
 
     [Parameter(Mandatory=$false)]
@@ -91,14 +99,49 @@ if (-not (Test-Path -Path $sharedHelpersPath)) {
 }
 . $sharedHelpersPath
 
-# Determine effective StartDate/EndDate defaults for whole current day if omitted
+function Resolve-EffectiveTimespan {
+    param(
+        [object]$Value,
+        [int]$DefaultMinutes = 15
+    )
+
+    if ($null -eq $Value -or [string]::IsNullOrWhiteSpace("$Value")) {
+        return [timespan]::FromMinutes($DefaultMinutes)
+    }
+
+    if ($Value -is [timespan]) { return $Value }
+    if ($Value -is [byte] -or $Value -is [int16] -or $Value -is [int32] -or $Value -is [int64] -or $Value -is [single] -or $Value -is [double] -or $Value -is [decimal]) {
+        return [timespan]::FromMinutes([double]$Value)
+    }
+
+    $minutes = 0.0
+    $textValue = "$Value".Trim()
+    if ([double]::TryParse($textValue, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$minutes)) {
+        return [timespan]::FromMinutes($minutes)
+    }
+
+    $parsedTimeSpan = [timespan]::Zero
+    if ([timespan]::TryParse($textValue, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsedTimeSpan)) {
+        return $parsedTimeSpan
+    }
+
+    throw "Invalid Timespan '$Value'. Provide a number (minutes) or a TimeSpan value."
+}
+
+# Determine effective StartDate/EndDate defaults
 $includeEndDate = $PSBoundParameters.ContainsKey('EndDate')
+if ($includeEndDate -and $PSBoundParameters.ContainsKey('Timespan')) {
+    throw 'Specify either EndDate or Timespan, not both.'
+}
+
 if (-not $PSBoundParameters.ContainsKey('StartDate')) {
     $StartDate = [datetime]::Today
-    if (-not $includeEndDate) {
-        $EndDate = $StartDate.Date.AddDays(1).AddMilliseconds(-1)
-        $includeEndDate = $true
-    }
+}
+
+if (-not $includeEndDate) {
+    $effectiveTimespan = Resolve-EffectiveTimespan -Value $Timespan
+    $EndDate = $StartDate.Add($effectiveTimespan)
+    $includeEndDate = $true
 }
 
 # Ensure output directory exists

--- a/SubflElasticInfo.md
+++ b/SubflElasticInfo.md
@@ -39,3 +39,8 @@ This note consolidates how Subscription Flow (SUBFL) scenarios log to Elasticsea
 - **BK._MOVENO**: movement identifier within a case, following the pattern `\d{5}`.
 
 The different CASENO values (`BK._CASENO`, `BK._CASENO_BC`, and `BK._CASENO_ISH`) represent the same underlying case, and most logs include all of them. When producing script output, display `BK._PID` as **AID** and `BK._PID_ISH` as **Fallzahl** to keep patient and case identifiers aligned.
+
+## Date-range parameters in SUBFL scripts
+- SUBFL scripts in this repository that expose `StartDate`/`EndDate` also accept `Timespan` as an alternative to `EndDate`.
+- `Timespan` supports either a numeric minute value or a PowerShell `TimeSpan` input.
+- If neither `EndDate` nor `Timespan` is provided, the scripts apply a default range of 15 minutes from `StartDate`.


### PR DESCRIPTION
### Motivation
- Make date-range handling more flexible by allowing callers to specify a duration instead of an explicit `EndDate` for scripts that already expose `StartDate`/`EndDate`.
- Provide a sensible default short window so scripts can be invoked with fewer parameters for quick lookups.
- Keep SUBFL-related documentation and script conventions in sync with the changed behavior.

### Description
- Added a new optional `Timespan` parameter (type `object`) to `Evaluate-AdmKavideErrors.ps1`, `Evaluate-OrchestraErrorsViaElastic.ps1`, `Process-MissingADM.ps1`, `Process-MissingMedarchiv.ps1`, and `Get-PatientInfo.ps1`, and updated their comment-based help accordingly.
- Implemented `Resolve-EffectiveTimespan` helper in each modified script to accept either a numeric value (interpreted as minutes) or a `TimeSpan` string and to return a `TimeSpan` instance, and added validation to forbid using `EndDate` and `Timespan` together.
- Made `EndDate` optional by deriving it from `StartDate + Timespan` when `EndDate` is omitted, and applied a default `Timespan` of 15 minutes when neither `EndDate` nor `Timespan` is provided; `Get-PatientInfo` also supports deriving `StartDate` from `EndDate` when appropriate (uses current time if both are omitted).
- Updated range/filter usage to rely on the new computed end-date flag (`includeEnd`/`includeEndDate`) and updated documentation files `README.md`, `SubflElasticInfo.md`, and `ScenarioInfo.md` to describe the repository-wide convention.

### Testing
- Performed PowerShell syntax validation by parsing each updated script with `pwsh -NoProfile -Command "[void][scriptblock]::Create((Get-Content -Raw '<script>'))"` for all modified scripts, and all parses completed successfully.
- Ran repository searches to verify `Timespan` and range flag usage were integrated into the expected locations, and the checks matched the intended changes (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ade7e99488333be28564ccc5c6bdf)