### PR TITLE
Align Create-ProcessModelOverview with ProcessModell_* naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
 - **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives, with optional mode selection, validation-category filtering, folder/PSC name filtering, and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
+- **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, and element-level parameter/assignment usage.
 
 ## Shared utilities
 
@@ -31,4 +32,3 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 ## Shared date-range behavior
 
 Scripts that expose `StartDate`/`EndDate` now also support `Timespan` as an alternative to `EndDate`. `Timespan` accepts either a number (minutes) or a PowerShell `TimeSpan` value. When `EndDate` and `Timespan` are both omitted, a default window of 15 minutes is used from `StartDate`.
-

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -40,6 +40,14 @@ Validation reads the following fields:
 - `/ProcessModel/pipelineMode`: `true`/`false` for pipeline mode.
 - `/ProcessModel/groupField`: Grouping field when scheduling is parallel grouped.
 
+`Create-ProcessModelOverview` additionally reads:
+
+- `/ProcessModel/ID`, `/ProcessModel/revisionNumber`, and `/ProcessModel/processSenarioID` for model metadata.
+- `/ProcessModel/properties/Property` to list process variables and process-level INPUT/OUTPUT/IN_OUT parameters.
+- `/ProcessModel/businessKeys/Property` to list business keys and types.
+- `/ProcessModel/processObjects/*` including `inAssignments`, `outAssignments`, and shape-level `parameters`/`properties`/`trigger/parameters`.
+- Element scripts and expressions (`script`, `sourceExpr/expression`, edge expressions, labels) to support optional unused-variable detection.
+
 Scheduling shorthand (used in naming conventions):
 
 - `p`: Parallel unbounded (`isFifo:false`, `isGroupedFifo:false`, `bestEffortLimit:0`, `pipelineMode:false`)

--- a/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
+++ b/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
@@ -1,0 +1,477 @@
+<#
+.SYNOPSIS
+    Creates a Markdown overview for one or more Orchestra process model files.
+
+.DESCRIPTION
+    Reads an Orchestra ProcessModel XML file and generates a structured overview that
+    includes basic process model metadata, process input/output parameters, variables,
+    business keys, and a per-element breakdown of assignments and parameters.
+
+    You can pass a single process model file via -ProcessModelPath or a folder via
+    -FolderPath. Folder mode scans for ProcessModell_* files (no extension) and
+    writes one Markdown file per input model.
+
+    The script prints a colored summary to the console and always writes a Markdown
+    report file next to the source process model (or into -OutputFolder if specified).
+
+.PARAMETER ProcessModelPath
+    Path to a single process model XML file.
+
+.PARAMETER FolderPath
+    Path to a folder that contains process model files.
+
+.PARAMETER OutputFolder
+    Optional output folder for generated Markdown files.
+
+.PARAMETER CheckUnusedVariables
+    Adds an "Unused Variables" section by checking declared process properties that are
+    not referenced in scripts, assignments, expressions, or shape parameter names.
+
+.EXAMPLE
+    .\Create-ProcessModelOverview.ps1 -ProcessModelPath .\ProcessModell_25
+
+.EXAMPLE
+    .\Create-ProcessModelOverview.ps1 -FolderPath .\ScenarioA -CheckUnusedVariables
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'File')]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'File')]
+    [string]$ProcessModelPath,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Folder')]
+    [string]$FolderPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputFolder,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$CheckUnusedVariables
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-TypeText {
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Xml.XmlNode]$TypeNode
+    )
+
+    if (-not $TypeNode) {
+        return ''
+    }
+
+    $parts = @()
+    if ($TypeNode.Attributes['class']) {
+        $parts += $TypeNode.Attributes['class'].Value
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($TypeNode.InnerText)) {
+        $parts += $TypeNode.InnerText.Trim()
+    }
+
+    if ($parts.Count -eq 0) {
+        return ''
+    }
+
+    return ($parts -join ':')
+}
+
+function ConvertTo-MarkdownTable {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Headers,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object[]]$Rows
+    )
+
+    if (-not $Rows -or $Rows.Count -eq 0) {
+        return "_none_"
+    }
+
+    $headerLine = '| ' + ($Headers -join ' | ') + ' |'
+    $separatorLine = '| ' + (($Headers | ForEach-Object { '---' }) -join ' | ') + ' |'
+
+    $dataLines = foreach ($row in $Rows) {
+        $values = foreach ($header in $Headers) {
+            $raw = ''
+            if ($row -is [hashtable] -and $row.ContainsKey($header)) {
+                $raw = [string]$row[$header]
+            } elseif ($row.PSObject.Properties[$header]) {
+                $raw = [string]$row.$header
+            }
+
+            if ([string]::IsNullOrWhiteSpace($raw)) {
+                ''
+            } else {
+                $raw.Replace('|', '\|').Replace("`r", ' ').Replace("`n", '<br/>').Trim()
+            }
+        }
+
+        '| ' + ($values -join ' | ') + ' |'
+    }
+
+    return @($headerLine, $separatorLine) + $dataLines
+}
+
+function Get-AssignmentList {
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Xml.XmlNode]$Parent,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AssignmentNodeName
+    )
+
+    if (-not $Parent) {
+        return @()
+    }
+
+    $assignmentContainer = $Parent.SelectSingleNode($AssignmentNodeName)
+    if (-not $assignmentContainer) {
+        return @()
+    }
+
+    $rows = New-Object System.Collections.Generic.List[object]
+    foreach ($assignment in $assignmentContainer.SelectNodes('Assignment')) {
+        $rows.Add([PSCustomObject]@{
+            Target = [string]$assignment.targetPropertyName
+            Expression = [string]$assignment.sourceExpr.expression
+            Language = [string]$assignment.sourceExpr.implementingLanguage
+        })
+    }
+
+    return $rows
+}
+
+function Get-PropertyRows {
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Xml.XmlNode]$Parent,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ContainerName
+    )
+
+    if (-not $Parent) {
+        return @()
+    }
+
+    $container = $Parent.SelectSingleNode($ContainerName)
+    if (-not $container) {
+        return @()
+    }
+
+    $rows = New-Object System.Collections.Generic.List[object]
+    foreach ($property in $container.SelectNodes('Property')) {
+        $rows.Add([PSCustomObject]@{
+            Name = [string]$property.name
+            Type = Get-TypeText -TypeNode $property.type
+            Usage = [string]$property.usagePattern
+            RequiredOnInput = [string]$property.requiredOnInput
+        })
+    }
+
+    return $rows
+}
+
+function Get-NodeInnerText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [xml]$XmlDocument,
+
+        [Parameter(Mandatory = $true)]
+        [string]$XPath
+    )
+
+    $node = $XmlDocument.SelectSingleNode($XPath)
+    if (-not $node -or [string]::IsNullOrWhiteSpace($node.InnerText)) {
+        return ''
+    }
+
+    return [string]$node.InnerText.Trim()
+}
+
+function Get-ElementTypeName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlNode]$Node
+    )
+
+    $rawName = [string]$Node.Name
+    if ($rawName -like '*.*') {
+        return ($rawName -split '\.')[-1]
+    }
+
+    return $rawName
+}
+
+function Get-UsedTextFragments {
+    param(
+        [Parameter(Mandatory = $true)]
+        [xml]$XmlDocument
+    )
+
+    $fragments = New-Object System.Collections.Generic.List[string]
+
+    foreach ($node in $XmlDocument.SelectNodes('//targetPropertyName|//expression|//script|//imports|//edgeLabel|//displayText')) {
+        if (-not [string]::IsNullOrWhiteSpace($node.InnerText)) {
+            $fragments.Add($node.InnerText)
+        }
+    }
+
+    return $fragments
+}
+
+function Test-IsVariableUsed {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$VariableName,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$TextFragments
+    )
+
+    if ([string]::IsNullOrWhiteSpace($VariableName)) {
+        return $false
+    }
+
+    $escapedName = [regex]::Escape($VariableName)
+    $pattern = "(?<![A-Za-z0-9_])$($escapedName)(?![A-Za-z0-9_])"
+
+    foreach ($text in $TextFragments) {
+        if ($text -match $pattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-ProcessModelFiles {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResolvedFolderPath
+    )
+
+    return @(Get-ChildItem -Path $ResolvedFolderPath -File -Filter 'ProcessModell_*' | Sort-Object -Property FullName -Unique)
+}
+
+function New-ProcessModelOverview {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ReportFolderPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeUnusedVariables
+    )
+
+    Write-Host "Processing $($FilePath)" -ForegroundColor Cyan
+
+    [xml]$xml = Get-Content -Path $FilePath -Raw
+    if ($xml.DocumentElement.LocalName -ne 'ProcessModel') {
+        throw "File '$($FilePath)' is not a ProcessModel XML."
+    }
+
+    $processName = [string]$xml.ProcessModel.name
+    if ([string]::IsNullOrWhiteSpace($processName)) {
+        $processName = [System.IO.Path]::GetFileName($FilePath)
+    }
+
+    $modelId = Get-NodeInnerText -XmlDocument $xml -XPath '/ProcessModel/ID'
+    $revisionNumber = Get-NodeInnerText -XmlDocument $xml -XPath '/ProcessModel/revisionNumber'
+    $processScenarioId = Get-NodeInnerText -XmlDocument $xml -XPath '/ProcessModel/processSenarioID'
+
+    $processParameters = New-Object System.Collections.Generic.List[object]
+    foreach ($property in $xml.SelectNodes('/ProcessModel/properties/Property')) {
+        $usage = [string]$property.usagePattern
+        if ($usage -in @('INPUT', 'OUTPUT', 'IN_OUT')) {
+            $processParameters.Add([PSCustomObject]@{
+                Name = [string]$property.name
+                Type = Get-TypeText -TypeNode $property.type
+                Usage = $usage
+                RequiredOnInput = [string]$property.requiredOnInput
+            })
+        }
+    }
+
+    $variables = New-Object System.Collections.Generic.List[object]
+    foreach ($property in $xml.SelectNodes('/ProcessModel/properties/Property')) {
+        $variables.Add([PSCustomObject]@{
+            Name = [string]$property.name
+            Type = Get-TypeText -TypeNode $property.type
+            Usage = [string]$property.usagePattern
+        })
+    }
+
+    $businessKeys = New-Object System.Collections.Generic.List[object]
+    foreach ($key in $xml.SelectNodes('/ProcessModel/businessKeys/Property')) {
+        $businessKeys.Add([PSCustomObject]@{
+            Name = [string]$key.name
+            Type = Get-TypeText -TypeNode $key.type
+            Usage = [string]$key.usagePattern
+        })
+    }
+
+    $elements = New-Object System.Collections.Generic.List[object]
+    foreach ($element in $xml.SelectNodes('/ProcessModel/processObjects/*')) {
+        $idNode = $element.SelectSingleNode('id')
+        if (-not $idNode) {
+            continue
+        }
+
+        $elementType = Get-ElementTypeName -Node $element
+        $inAssignments = Get-AssignmentList -Parent $element -AssignmentNodeName 'inAssignments'
+        $outAssignments = Get-AssignmentList -Parent $element -AssignmentNodeName 'outAssignments'
+        $shapeParameters = @()
+
+        if ($element.SelectSingleNode('parameters')) {
+            $shapeParameters = Get-PropertyRows -Parent $element -ContainerName 'parameters'
+        } elseif ($element.SelectSingleNode('properties')) {
+            $shapeParameters = Get-PropertyRows -Parent $element -ContainerName 'properties'
+        } elseif ($element.SelectSingleNode('trigger/parameters')) {
+            $shapeParameters = Get-PropertyRows -Parent $element.SelectSingleNode('trigger') -ContainerName 'parameters'
+        }
+
+        $elements.Add([PSCustomObject]@{
+            ElementId = [string]$idNode.InnerText
+            Name = [string]$element.displayText
+            Type = $elementType
+            InAssignments = $inAssignments
+            OutAssignments = $outAssignments
+            Parameters = $shapeParameters
+        })
+    }
+
+    $unusedVariables = @()
+    if ($IncludeUnusedVariables) {
+        $fragments = Get-UsedTextFragments -XmlDocument $xml
+        $unusedVariables = @(
+            $variables | Where-Object {
+                -not (Test-IsVariableUsed -VariableName $_.Name -TextFragments $fragments)
+            }
+        )
+    }
+
+    $baseOutputFolder = $ReportFolderPath
+    if ([string]::IsNullOrWhiteSpace($baseOutputFolder)) {
+        $baseOutputFolder = Split-Path -Path $FilePath -Parent
+    }
+
+    if (-not (Test-Path -LiteralPath $baseOutputFolder)) {
+        $null = New-Item -Path $baseOutputFolder -ItemType Directory -Force
+    }
+
+    $sourceFileName = [System.IO.Path]::GetFileNameWithoutExtension($FilePath)
+    if ([string]::IsNullOrWhiteSpace($sourceFileName)) {
+        $sourceFileName = [System.IO.Path]::GetFileName($FilePath)
+    }
+
+    $outputPath = Join-Path -Path $baseOutputFolder -ChildPath "$($sourceFileName)_Overview.md"
+
+    $md = New-Object System.Collections.Generic.List[string]
+    $md.Add("# ProcessModel Overview: $($processName)")
+    $md.Add('')
+    $md.Add('## Basic Information')
+    $md.Add('')
+    $md.Add("- Source file: " + [System.IO.Path]::GetFileName($FilePath))
+    $md.Add("- Process name: " + $processName)
+    $md.Add("- Process model ID: " + $modelId)
+    $md.Add("- Scenario ID: " + $processScenarioId)
+    $md.Add("- Revision: " + $revisionNumber)
+    $md.Add('')
+    $md.Add('### ProcessModel Input/Output Parameters')
+    $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Name','Type','Usage','RequiredOnInput') -Rows $processParameters))
+    $md.Add('')
+    $md.Add('## Used Variables')
+    $md.Add('')
+    $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Name','Type','Usage') -Rows $variables))
+    $md.Add('')
+    $md.Add('## Used BusinessKeys')
+    $md.Add('')
+    $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Name','Type','Usage') -Rows $businessKeys))
+    $md.Add('')
+    $md.Add('## Used Elements')
+    $md.Add('')
+
+    foreach ($element in $elements) {
+        $md.Add("### $($element.Name)")
+        $md.Add('')
+        $md.Add("- Element ID: " + $element.ElementId)
+        $md.Add("- Type: " + $element.Type)
+        $md.Add('')
+        $md.Add('#### Input Assignments')
+        $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Target','Expression','Language') -Rows $element.InAssignments))
+        $md.Add('')
+        $md.Add('#### Output Assignments')
+        $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Target','Expression','Language') -Rows $element.OutAssignments))
+        $md.Add('')
+        $md.Add('#### Shape Parameters')
+        $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Name','Type','Usage','RequiredOnInput') -Rows $element.Parameters))
+        $md.Add('')
+    }
+
+    if ($IncludeUnusedVariables) {
+        $md.Add('## Unused Variables')
+        $md.Add('')
+        $md.AddRange([string[]](ConvertTo-MarkdownTable -Headers @('Name','Type','Usage') -Rows $unusedVariables))
+        $md.Add('')
+    }
+
+    Set-Content -Path $outputPath -Value $md -Encoding UTF8
+
+    Write-Host "  Process: $($processName)" -ForegroundColor Green
+    Write-Host "  Variables: $($variables.Count), BusinessKeys: $($businessKeys.Count), Elements: $($elements.Count)" -ForegroundColor Yellow
+    if ($IncludeUnusedVariables) {
+        Write-Host "  Unused Variables: $($unusedVariables.Count)" -ForegroundColor Magenta
+    }
+    Write-Host "  Overview file: $($outputPath)" -ForegroundColor Cyan
+
+    return [PSCustomObject]@{
+        InputFile = $FilePath
+        OutputFile = $outputPath
+        ProcessName = $processName
+        VariableCount = $variables.Count
+        BusinessKeyCount = $businessKeys.Count
+        ElementCount = $elements.Count
+        UnusedVariableCount = if ($IncludeUnusedVariables) { $unusedVariables.Count } else { $null }
+    }
+}
+
+$inputFiles = @()
+if ($PSCmdlet.ParameterSetName -eq 'File') {
+    $resolved = (Resolve-Path -Path $ProcessModelPath).Path
+    if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+        throw "ProcessModelPath is not a file: $($resolved)"
+    }
+    $inputFiles = @($resolved)
+} else {
+    $resolvedFolder = (Resolve-Path -Path $FolderPath).Path
+    if (-not (Test-Path -LiteralPath $resolvedFolder -PathType Container)) {
+        throw "FolderPath is not a folder: $($resolvedFolder)"
+    }
+
+    $inputFiles = @(Get-ProcessModelFiles -ResolvedFolderPath $resolvedFolder | ForEach-Object { $_.FullName })
+    if ($inputFiles.Count -eq 0) {
+        Write-Warning "No ProcessModell_* files found in '$($resolvedFolder)'."
+        return
+    }
+}
+
+$resolvedOutputFolder = $null
+if ($PSBoundParameters.ContainsKey('OutputFolder') -and -not [string]::IsNullOrWhiteSpace($OutputFolder)) {
+    $resolvedOutputFolder = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputFolder)
+}
+
+$results = foreach ($file in $inputFiles) {
+    New-ProcessModelOverview -FilePath $file -ReportFolderPath $resolvedOutputFolder -IncludeUnusedVariables:$CheckUnusedVariables
+}
+
+Write-Host ''
+Write-Host "Finished. Created $($results.Count) overview file(s)." -ForegroundColor Green


### PR DESCRIPTION
### Motivation
- The process model export naming is always `ProcessModell_*` (double `l`, no extension), so folder-mode scanning and documentation should reflect that canonical pattern. 
- Avoid accidental matches or missed files by restricting the script to the exact filename convention used in exports. 
- Keep user-facing help and repository docs consistent with the scripts' behavior.

### Description
- Updated `Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1` to only scan for `ProcessModell_*` files by changing `Get-ProcessModelFiles` and related warning/help text to the strict naming. 
- Adjusted script help/comment block examples and the folder-mode warning to mention `ProcessModell_*` explicitly. 
- Updated `ScenarioInfo.md` and `README.md` to state that process model files are `ProcessModell_*` (no extension) and to reference the new script behavior.

### Testing
- Ran single-file mode with `pwsh -NoProfile -File Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1 -ProcessModelPath /tmp/Processmodel_01 -CheckUnusedVariables` and confirmed an overview file was produced successfully. 
- Ran folder mode after copying a sample to `/tmp/pmfolder2/ProcessModell_01` and executed `pwsh -NoProfile -File Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1 -FolderPath /tmp/pmfolder2`, confirming the overview file was generated. 
- Both automated runs completed successfully and the generated Markdown contained the expected sections and counts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69931be5b0848333a2c34df922fbb14e)