### PR TITLE
Fix Create-ProcessModelOverview when Property/type is missing

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -46,6 +46,7 @@ Validation reads the following fields:
 - `/ProcessModel/properties/Property` to list process variables and process-level INPUT/OUTPUT/IN_OUT parameters.
 - `/ProcessModel/businessKeys/Property` to list business keys and types.
 - `/ProcessModel/processObjects/*` including `inAssignments`, `outAssignments`, and shape-level `parameters`/`properties`/`trigger/parameters`.
+- Property and business key type metadata from optional child node `type`; missing type nodes are treated as empty values.
 - Element scripts and expressions (`script`, `sourceExpr/expression`, edge expressions, labels) to support optional unused-variable detection.
 
 Scheduling shorthand (used in naming conventions):

--- a/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
+++ b/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
@@ -169,7 +169,7 @@ function Get-PropertyRows {
     foreach ($property in $container.SelectNodes('Property')) {
         $rows.Add([PSCustomObject]@{
             Name = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'name'
-            Type = Get-TypeText -TypeNode $property.type
+            Type = Get-TypeText -TypeNode ($property.SelectSingleNode('type'))
             Usage = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'usagePattern'
             RequiredOnInput = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'requiredOnInput'
         })
@@ -315,7 +315,7 @@ function New-ProcessModelOverview {
         if ($usage -in @('INPUT', 'OUTPUT', 'IN_OUT')) {
             $processParameters.Add([PSCustomObject]@{
                 Name = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'name'
-                Type = Get-TypeText -TypeNode $property.type
+                Type = Get-TypeText -TypeNode ($property.SelectSingleNode('type'))
                 Usage = $usage
                 RequiredOnInput = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'requiredOnInput'
             })
@@ -326,7 +326,7 @@ function New-ProcessModelOverview {
     foreach ($property in $xml.SelectNodes('/ProcessModel/properties/Property')) {
         $variables.Add([PSCustomObject]@{
             Name = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'name'
-            Type = Get-TypeText -TypeNode $property.type
+            Type = Get-TypeText -TypeNode ($property.SelectSingleNode('type'))
             Usage = Get-ChildNodeInnerText -ParentNode $property -ChildNodeName 'usagePattern'
         })
     }
@@ -335,7 +335,7 @@ function New-ProcessModelOverview {
     foreach ($key in $xml.SelectNodes('/ProcessModel/businessKeys/Property')) {
         $businessKeys.Add([PSCustomObject]@{
             Name = Get-ChildNodeInnerText -ParentNode $key -ChildNodeName 'name'
-            Type = Get-TypeText -TypeNode $key.type
+            Type = Get-TypeText -TypeNode ($key.SelectSingleNode('type'))
             Usage = Get-ChildNodeInnerText -ParentNode $key -ChildNodeName 'usagePattern'
         })
     }


### PR DESCRIPTION
### Motivation

- Prevent the `PropertyNotFoundStrict` error thrown by `New-ProcessModelOverview` when a `Property` or business key node lacks a child `type` element under strict mode.
- Make `Create-ProcessModelOverview` robust for real-world `ProcessModell_*` files that omit optional `type` metadata.

### Description

- Replace direct member access like `$property.type` with explicit XPath lookup `($property.SelectSingleNode('type'))` in `Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1` for process parameters, variables, and business keys.
- Apply the same `SelectSingleNode('type')` change inside `Get-PropertyRows` so shape/property lookups do not assume a `type` child exists.
- Update `ScenarioInfo.md` to document that `type` child nodes are optional and are treated as empty values when missing.

### Testing

- Ran `pwsh -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'` to verify the PowerShell runtime, which succeeded.
- Executed `pwsh -NoProfile -File Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1 -ProcessModelPath /tmp/ProcessModell_test_missing_type.xml -OutputFolder /tmp` using a test `ProcessModel` XML that omits `type` nodes, which completed successfully and produced the overview file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69931f8000f88333afb9e9456625665e)