### PR TITLE
Fix Create-ProcessModelOverview result counting for single file runs

### DIFF
--- a/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
+++ b/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
@@ -490,9 +490,9 @@ if ($PSBoundParameters.ContainsKey('OutputFolder') -and -not [string]::IsNullOrW
     $resolvedOutputFolder = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputFolder)
 }
 
-$results = foreach ($file in $inputFiles) {
+$results = @(foreach ($file in $inputFiles) {
     New-ProcessModelOverview -FilePath $file -ReportFolderPath $resolvedOutputFolder -IncludeUnusedVariables:$CheckUnusedVariables
-}
+})
 
 Write-Host ''
 Write-Host "Finished. Created $($results.Count) overview file(s)." -ForegroundColor Green


### PR DESCRIPTION
### Motivation
- Prevent a `PropertyNotFoundStrict` runtime error when the script processes exactly one process model and `$results` is not an array, so accessing `$results.Count` fails under `Set-StrictMode`.

### Description
- Ensure the generation results are always collected as an array by wrapping the `foreach` in `@(...)` in `Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1` so `$results` is consistently an array.

### Testing
- Verified `pwsh` is available via `pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'` and executed the script against a minimal sample `/tmp/ProcessModell_Test.xml`, which completed with `Finished. Created 1 overview file(s).` and produced `/tmp/ProcessModell_Test_Overview.md`, all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699320ed499c8333afd52ddcd5c16fb4)