### PR TITLE
Adjust Create-ProcessModelOverview output layout and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
 - **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives, with optional mode selection, validation-category filtering, folder/PSC name filtering, and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
-- **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, and element-level parameter/assignment usage.
+- **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, and element-level parameter/assignment usage, writing reports to the script-local `Output` folder by default.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -48,6 +48,9 @@ Validation reads the following fields:
 - `/ProcessModel/processObjects/*` including `inAssignments`, `outAssignments`, and shape-level `parameters`/`properties`/`trigger/parameters`.
 - Property and business key type metadata from optional child node `type`; missing type nodes are treated as empty values.
 - Element scripts and expressions (`script`, `sourceExpr/expression`, edge expressions, labels) to support optional unused-variable detection.
+- Overview reports default to `<script folder>/Output` unless `-OutputFolder` is supplied.
+- Type values in the overview output use the type name text only (for example `string`).
+- Element headings include type and element ID directly in the heading, and empty assignment/parameter sections are omitted.
 
 Scheduling shorthand (used in naming conventions):
 


### PR DESCRIPTION
### Motivation
- Make the overview output easier to discover by defaulting reports to a script-local `Output` folder instead of the source model directory.
- Simplify and normalize type rendering to emit only the type name text for clearer tables.
- Remove empty/placeholder table output and avoid emitting blank variable rows to produce more compact, meaningful reports.
- Improve element headings to include type and element ID so consumers can see key metadata inline.

### Description
- Updated the script help text and behavior so the default report target is the script-local `Output` folder when `-OutputFolder` is not supplied, implemented by setting the base output path to `Join-Path -Path $PSScriptRoot -ChildPath 'Output'`.
- Simplified `Get-TypeText` to return only the `InnerText` of the `type` node (or empty string) so types render as plain names (for example `string`).
- Changed `ConvertTo-MarkdownTable` to return an empty list (`@()`) for empty input instead of returning `"_none_"`, and updated the markdown generation to skip empty sections/tables.
- Filtered declared process variables to skip entries with blank names before adding them to the `Used Variables` table.
- Reworked element output so headings include `Type` and `ElementID` inline (`Name [Type: ..., ElementID: ...]`) and input/output/parameter subsections are omitted when empty.
- Updated `README.md` and `ScenarioInfo.md` to document the new default output location and the adjusted overview formatting behavior.

### Testing
- Ran a PowerShell syntax/parse check with `pwsh -NoProfile -File /tmp/parse_check.ps1` against `Create-ProcessModelOverview.ps1`, which succeeded (Parse OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699323df8d5c833399b073c98143170f)