### PR TITLE
Normalize single-item assignment/parameter results to arrays in Create-ProcessModelOverview

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -51,6 +51,7 @@ Validation reads the following fields:
 - Overview reports default to `<script folder>/Output` unless `-OutputFolder` is supplied.
 - Type values in the overview output use the type name text only (for example `string`).
 - Element headings include type and element ID directly in the heading, and empty assignment/parameter sections are omitted.
+- Assignment and parameter rows are normalized to arrays so single-row sections are handled consistently under strict mode.
 
 Scheduling shorthand (used in naming conventions):
 

--- a/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
+++ b/Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1
@@ -346,16 +346,16 @@ function New-ProcessModelOverview {
         }
 
         $elementType = Get-ElementTypeName -Node $element
-        $inAssignments = Get-AssignmentList -Parent $element -AssignmentNodeName 'inAssignments'
-        $outAssignments = Get-AssignmentList -Parent $element -AssignmentNodeName 'outAssignments'
+        $inAssignments = @(Get-AssignmentList -Parent $element -AssignmentNodeName 'inAssignments')
+        $outAssignments = @(Get-AssignmentList -Parent $element -AssignmentNodeName 'outAssignments')
         $shapeParameters = @()
 
         if ($element.SelectSingleNode('parameters')) {
-            $shapeParameters = Get-PropertyRows -Parent $element -ContainerName 'parameters'
+            $shapeParameters = @(Get-PropertyRows -Parent $element -ContainerName 'parameters')
         } elseif ($element.SelectSingleNode('properties')) {
-            $shapeParameters = Get-PropertyRows -Parent $element -ContainerName 'properties'
+            $shapeParameters = @(Get-PropertyRows -Parent $element -ContainerName 'properties')
         } elseif ($element.SelectSingleNode('trigger/parameters')) {
-            $shapeParameters = Get-PropertyRows -Parent $element.SelectSingleNode('trigger') -ContainerName 'parameters'
+            $shapeParameters = @(Get-PropertyRows -Parent $element.SelectSingleNode('trigger') -ContainerName 'parameters')
         }
 
         $elements.Add([PSCustomObject]@{


### PR DESCRIPTION
### Motivation
- Prevent `PropertyNotFoundException` in strict mode when an element has exactly one assignment or one parameter/property row because PowerShell unrolls single-item collections into scalars and those scalars do not have a `Count` property.

### Description
- Wrap results from `Get-AssignmentList` and `Get-PropertyRows` with `@(...)` so `InAssignments`, `OutAssignments`, and `Parameters` are always arrays in `Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1`.
- Update `ScenarioInfo.md` to document that assignment and parameter rows are normalized to arrays for consistent single-row handling.

### Testing
- Executed `pwsh -NoLogo -File Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1 -ProcessModelPath /tmp/ProcessModell_single -OutputFolder /tmp/pm-out` against a synthetic `ProcessModell_*` XML containing exactly one in-assignment and one parameter row, and the script completed successfully and produced the overview file without the previous `Count` error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69932538e2f48333bd27693fbdffad08)