### PR TITLE
Handle empty assignment/parameter arrays and empty edge collections in Create-ProcessModelOverview

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -54,6 +54,7 @@ Validation reads the following fields:
 - Element headings use compact `[Type, ElementID]` formatting.
 - Input assignments, output assignments, and parameters are merged into one per-element detail table.
 - Assignment and parameter rows are normalized to arrays so single-row sections are handled consistently under strict mode.
+- Elements without assignments, parameters, or gateway edges are handled as empty collections so overview generation does not fail under strict mode.
 
 Scheduling shorthand (used in naming conventions):
 


### PR DESCRIPTION
### Motivation
- Prevent parameter-binding failures when elements have no `inAssignments`, `outAssignments`, or `parameters`, which previously caused `ParameterArgumentValidationErrorEmptyArrayNotAllowed` under strict mode.
- Ensure non-gateway elements preserve an empty outgoing-edge collection so downstream code expecting `.Count` does not fail.

### Description
- Relaxed `Get-ElementDetailRows` parameter validation by making `InAssignments`, `OutAssignments`, and `Parameters` optional, adding `[AllowEmptyCollection()]`, and defaulting them to `@()` so empty arrays are accepted.
- Refactored element construction in `New-ProcessModelOverview` to compute `detailRows` and `outgoingEdges` into variables and assign those to the element object to guarantee empty collections for elements without assignments or gateway edges.
- Updated `ScenarioInfo.md` to document that elements without assignments, parameters, or gateway edges are handled as empty collections.

### Testing
- Parsed the modified script with the PowerShell parser using `[System.Management.Automation.Language.Parser]::ParseFile(...)` to validate syntax, which returned `Parse OK`.
- Executed the script against a minimal `ProcessModel` sample lacking assignments and gateway edges with `pwsh -NoProfile -File Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1 -ProcessModelPath /tmp/ProcessModell_Test -OutputFolder /tmp/pm_overview_test`, and the overview was generated successfully without binding errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699328cd852c8333b8ad4920392b0dea)