### PR TITLE
Fix GatewayExclusiveDecision edge resolution in Create-ProcessModelOverview

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
 - **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives, with optional mode selection, validation-category filtering, folder/PSC name filtering, and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
-- **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, and merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`) plus gateway outgoing edge conditions, writing reports to the script-local `Output` folder by default.
+- **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -46,7 +46,7 @@ Validation reads the following fields:
 - `/ProcessModel/properties/Property` to list process variables and process-level INPUT/OUTPUT/IN_OUT parameters.
 - `/ProcessModel/businessKeys/Property` to list business keys and types.
 - `/ProcessModel/processObjects/*` including `inAssignments`, `outAssignments`, and shape-level `parameters`/`properties`/`trigger/parameters`.
-- `/ProcessModel/edges/*`, `/ProcessModel/processEdges/*`, and `/ProcessModel/sequenceFlows/*` to list outgoing gateway edge conditions and optional edge display names.
+- `/ProcessModel/edges/*`, `/ProcessModel/processEdges/*`, `/ProcessModel/sequenceFlows/*`, and `/ProcessModel/EdgeSequence` to list outgoing gateway edge conditions and optional edge display names, including else branches when no edge expression exists.
 - Property and business key type metadata from optional child node `type`; missing type nodes are treated as empty values.
 - Element scripts and expressions (`script`, `sourceExpr/expression`, edge expressions, labels) to support optional unused-variable detection.
 - Overview reports default to `<script folder>/Output` unless `-OutputFolder` is supplied.


### PR DESCRIPTION
### Motivation
- Gateway outgoing edges that are represented via `EdgeSequence` and `m__arNode` references were not being detected, causing gateway branches (including else/fallback paths) to be omitted from the generated overviews.

### Description
- Extended `Get-EdgeRows` to accept an optional `SourceReferenceId` parameter and include `/ProcessModel/EdgeSequence` when scanning for edges.  
- Added logic to match edges by the first `m__arNode` child `reference` attribute when classic source fields do not match.  
- Improved expression extraction to check nested `expression/expression` nodes and set branch `Condition` to `'else'` when no expression exists.  
- Propagated the element attribute `id` as `SourceReferenceId` when calling `Get-EdgeRows` for gateway elements.  
- Updated `README.md` and `ScenarioInfo.md` to document EdgeSequence support and else-branch visibility.

### Testing
- Ran PowerShell version check with `pwsh -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'` which succeeded.  
- Executed `Create-ProcessModelOverview.ps1` against a synthetic `ProcessModell_test_gateway.xml` using `pwsh -NoProfile -File Scripts/Create-ProcessModelOverview/Create-ProcessModelOverview.ps1 -ProcessModelPath /tmp/ProcessModell_test_gateway.xml -OutputFolder /tmp/overview_test` and verified the generated Markdown contains both the Java expression branch and an `else` branch.  
- Performed `git diff`/`git status` and committed the changes; all checks and the manual verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69932c7fe2d08333979ab1c138410c2d)