### PR TITLE
Handle-OrchestraGit: add Update/Pull/Reset actions, fix exclude entry and duplicate-root handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-OrchestraErrorsViaElastic.ps1** - Aggregates failed Orchestra scenarios from Elasticsearch and optionally exports normalized error XML.
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
-- **Handle-OrchestraGit.ps1** - Scans Orchestra git repositories, ensures required local excludes, and reports one-line repository status summaries.
+- **Handle-OrchestraGit.ps1** - Scans Orchestra git repositories, ensures required local excludes, reports one-line repository status summaries, and supports update/reset actions.
 - **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives, with optional mode selection, validation-category filtering, folder/PSC name filtering, and optional text report output (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.


### PR DESCRIPTION
### Motivation
- Ensure the `.git/info/exclude` contains the correct entry for Orchestra credentials and prevent a repository root being processed twice when the script is pointed directly at a repo. 
- Provide convenient repository sync actions to safely update repositories when they are behind or to force-reset when needed. 

### Description
- Changed the required exclude entry from `/orc.cred` to `/.orc.cred` and updated the script help and `ValidateSet` to include `Update`, `Pull`, and `Reset` actions. 
- Fixed duplicate processing by normalizing paths with `Get-NormalizedPath`, skipping the root `.git` match during recursive discovery, and storing normalized repository roots. 
- Added `Get-UpstreamVersionLabel` to format "Update available" as upstream tag + short commit hash (or short hash when no tag) and returned additional status fields (`HasPendingChanges`, `Upstream`). 
- Implemented `Invoke-RepositoryAction` to perform `Update`/`Pull` as fast-forward pulls only when there are no pending changes and the upstream exists, and `Reset` as a hard-reset to the upstream ref; status is re-evaluated and printed after actions. 
- Updated `README.md` to reflect the new update/reset capabilities. 

### Testing
- Validated syntax with the PowerShell parser using ` [System.Management.Automation.Language.Parser]::ParseFile('Scripts/Handle-OrchestraGit/Handle-OrchestraGit.ps1',[ref]$tokens,[ref]$errors)` which reported no errors. 
- Executed the script for functional checks with `pwsh -NoProfile -File Scripts/Handle-OrchestraGit/Handle-OrchestraGit.ps1 -Path . -Action Status` and observed expected status output. 
- Exercised the new actions with `-Action Update` and `-Action Pull` to verify the fast-forward behavior and that the script runs end-to-end without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699583e6b3d88333a69e7dca185fcf97)