### PR TITLE
Sort Validate-Scenarios output by normalized scenario name

### DIFF
--- a/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.ps1
@@ -664,7 +664,15 @@ if (-not $scenariosWithIssues) {
     Add-OutputLine -Line 'Scenario Validation Results (Incorrect Configurations):'
     Add-OutputLine -Line ''
 
-    foreach ($scenario in $scenariosWithIssues | Sort-Object Name) {
+    $sortedScenarios = $scenariosWithIssues | Sort-Object -Property @{ Expression = {
+        if ($_.Name) {
+            $_.Name.Trim().ToUpperInvariant()
+        } else {
+            ''
+        }
+    }}
+
+    foreach ($scenario in $sortedScenarios) {
         Write-Host -NoNewline $scenario.Name -ForegroundColor $scenarioColor
         Write-Host " [$($scenario.Path)]"
         Add-OutputLine -Line "$($scenario.Name) [$($scenario.Path)]"


### PR DESCRIPTION
### Motivation
- Ensure `Validate-Scenarios` prints scenario entries in a stable, alphabetical order regardless of name casing or surrounding whitespace by normalizing names prior to sorting.

### Description
- Replace the direct `Sort-Object Name` iteration with a pre-sorted collection using `Sort-Object -Property @{ Expression = { $_.Name.Trim().ToUpperInvariant() } }` and iterate over `$sortedScenarios`, leaving the existing output structure unchanged.

### Testing
- Ran the script with `pwsh` against a temporary path containing folders `Alpha` and `zeta` and verified the command-line output lists `Alpha` before `zeta`, indicating the sorting change worked as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69958fc987b8833380a8790b95122e3f)