### PR TITLE
Require all process models sequential for ST exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
 - **Handle-OrchestraGit.ps1** - Scans Orchestra git repositories, ensures required local excludes, reports fixed-width status lines, and supports update/reset actions (reset also removes untracked files).
-- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives, with optional mode selection, validation-category filtering, folder/PSC name filtering, and optional text report output (ignores non-XML PSC entries).
+- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives with optional mode/category/name filters and optional text report output; allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -77,6 +77,8 @@ Validation reads channel fields from the document root regardless of the specifi
 
 A channel is considered non-concurrent when `numberOfInstances` is `1`.
 
+Sequential channels are allowed when all process models in the same scenario use sequential scheduling (`isFifo:true`, `isGroupedFifo:false`, `bestEffortLimit:0`, `pipelineMode:false`).
+
 ## Message mapping files (`MessageMapping_*`)
 
 XML root name: `emds.mapping.proc.MappingScript`.
@@ -89,6 +91,8 @@ Validation reads:
 - `/emds.mapping.proc.MappingScript/parallelExecution`: `true`/`false` concurrency flag.
 
 Mappings are flagged when `parallelExecution` is not `true`.
+
+Sequential mappings are allowed when all process models in the same scenario use sequential scheduling (`isFifo:true`, `isGroupedFifo:false`, `bestEffortLimit:0`, `pipelineMode:false`).
 
 ## Naming conventions
 


### PR DESCRIPTION
### Motivation
- The ST (resource usage strategy) allowance should only apply when every process model in a scenario is sequential, not when a single process model is sequential.
- Existing scenario-level boolean tracking was insufficient to decide the exception when multiple process models exist in a scenario.

### Description
- Added per-process-model detection via `Test-IsSequentialScenarioProcessModel` and introduced `scenarioProcessModelStats` counters (`Total`, `Sequential`) to track per-scenario stats.
- Replaced the previous scenario-level boolean approach with counters and updated `Add-ScenarioResult` to increment `Total` and `Sequential` when processing process model files.
- Added `Remove-SequentialStrategyIssues` and `Test-ScenarioIsFullySequential`, and perform a post-processing pass that removes `ST:s` findings from channels and mappings only when `Sequential -eq Total` for the scenario.
- Updated documentation and script header text in `README.md` and `ScenarioInfo.md` to state that sequential channels/mappings are allowed only when all process models in the scenario are sequential, and added the process model XPath entries (`isGroupedFifo`, `bestEffortLimit`, `pipelineMode`) used for detection.

### Testing
- Performed a PowerShell syntax/load check with `pwsh -NoProfile -Command "[void][scriptblock]::Create((Get-Content -Path 'Scripts/Validate-Scenarios/Validate-Scenarios.ps1' -Raw)); 'OK'"`, which succeeded.
- Ran the validator end-to-end with `pwsh -NoProfile -File Scripts/Validate-Scenarios/Validate-Scenarios.ps1 -Path .`, which executed and reported `No incorrect configurations found.` and `Total number of files processed: 0`, indicating the script runs without runtime errors in this repository state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699591efd6a4833384b186fe8fdb24d1)