### PR TITLE
Fix Validate-Scenarios empty-array binding and add progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
 - **Handle-OrchestraGit.ps1** - Scans Orchestra git repositories, ensures required local excludes, reports fixed-width status lines, and supports update/reset actions (reset also removes untracked files).
-- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives with optional mode/category/name filters and optional text report output; allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
+- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives with optional mode/category/name filters, shows validation progress, and can write a text report; allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -155,6 +155,8 @@ Supported exception codes:
 
 When the script finds a non-default configuration that matches an exception code, it suppresses the entry by default and can optionally list it with an "exception configured" note.
 
+Validation now reports progress while scanning folder files and PSC archive entries.
+
 ## Orchestra git working copy notes
 
 Orchestra scenario working copies often contain local machine artifacts that should stay untracked.


### PR DESCRIPTION
### Motivation
- Prevent runtime failure when `Remove-SequentialStrategyIssues` is invoked with an empty `Channels` or `Mappings` collection. 
- Provide visible feedback during long-running validations of folder files and PSC archives. 
- Keep repository documentation in sync with the new progress behavior for the script.

### Description
- Allow `Remove-SequentialStrategyIssues` to accept empty collections by adding the `[AllowEmptyCollection()]` attribute to the `-Entries` parameter. 
- Add a new helper `Update-ValidationProgress` that computes percent complete and calls `Write-Progress`. 
- Integrate progress updates into the folder file loop, PSC archive loop, and per-archive-entry processing, and clear the progress UI at the end with `Write-Progress -Completed`. 
- Update `README.md` and `ScenarioInfo.md` to mention the new validation progress behavior. 

### Testing
- Verified script parses cleanly with the PowerShell parser using `pwsh -NoProfile -Command '[System.Management.Automation.Language.Parser]::ParseFile("Scripts/Validate-Scenarios/Validate-Scenarios.ps1", [ref]$tokens, [ref]$errors) | Out-Null; if($errors.Count -eq 0){"OK"} else {$errors | ForEach-Object { $_.Message }; exit 1 }'`, which returned no parse errors. 
- Basic repository checks (`rg`/file inspections) were used to confirm the new functions and documentation lines were added as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69959d2bbfac83339e2807a16cb50b9b)