### PR TITLE
Handle channel strategy via isSynchronous fallback in Validate-Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Evaluate-AdmKavideErrors.ps1** - Collects and summarizes Kavide scenario errors from Elasticsearch with per-case details.
 - **Get-PatientInfo.ps1** - Retrieves SUBFL HCM messages for a patient or case and exports structured JSON.
 - **Handle-OrchestraGit.ps1** - Scans Orchestra git repositories, ensures required local excludes, reports fixed-width status lines, and supports update/reset actions (reset also removes untracked files).
-- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives with optional mode/category/name filters, shows validation progress, and can write a text report; allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
+- **Validate-Scenarios.ps1** - Validates scenario folders or PSC archives with optional mode/category/name filters, shows validation progress, and can write a text report; derives channel strategy from `numberOfInstances` or `isSynchronous`, and allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -73,9 +73,10 @@ Each channel XML supports a `description` element directly below the root. Valid
 Validation reads channel fields from the document root regardless of the specific channel type:
 
 - `/*/name`: Channel name.
-- `/*/numberOfInstances`: Concurrency count.
+- `/*/numberOfInstances`: Concurrency count (when available).
+- `/*/isSynchronous`: Synchronous execution flag (used when `numberOfInstances` is not present).
 
-A channel is considered non-concurrent when `numberOfInstances` is `1`.
+A channel is considered non-concurrent when either `numberOfInstances` is `1` or `isSynchronous` is `true`.
 
 Sequential channels are allowed when all process models in the same scenario use sequential scheduling (`isFifo:true`, `isGroupedFifo:false`, `bestEffortLimit:0`, `pipelineMode:false`).
 


### PR DESCRIPTION
### Motivation
- Some channel XMLs use `isSynchronous` instead of `numberOfInstances`; validation must detect channel strategy from either tag so sequential/parallel checks are accurate. 
- Keep default behavior conservative (treat unknown as parallel) and avoid raising false ST issues when a valid tag indicates sequential.
- Documentation should reflect both supported fields so users know which tags influence the check.

### Description
- Updated `Scripts/Validate-Scenarios/Validate-Scenarios.ps1` to read `/*/isSynchronous` and compute `strategyCode` by using `numberOfInstances` when present, otherwise falling back to `isSynchronous` with a case-insensitive `true` -> `s` mapping; default remains `p` if neither tag exists. 
- Amended the script header `Description` text to mention channel strategy is derived from `numberOfInstances` or `isSynchronous`. 
- Updated `README.md` and `ScenarioInfo.md` to document the dual-tag channel strategy behavior and the non-concurrent rule (either `numberOfInstances = 1` or `isSynchronous = true`).

### Testing
- Verified the modified script parses without syntax errors using the PowerShell parser: `pwsh -NoProfile -Command '[ref]$tokens,[ref]$errors; [void][System.Management.Automation.Language.Parser]::ParseFile("Scripts/Validate-Scenarios/Validate-Scenarios.ps1",[ref]$tokens,[ref]$errors); if($errors.Count -eq 0){"OK"} else {$errors | ForEach-Object { $_.Message }; exit 1 }'`, which returned `OK`.
- Confirmed repository files were updated and staged; commit completed successfully (3 files changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996eb00c474833385d4109d4a95bdc0)