### PR TITLE
Rename AnalyzeOrchestraLog to Analyze-OrchestraLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 
 - **Add-HostNames.ps1** - Resolves IP addresses from a CSV file to host names and writes the enriched CSV.
 - **Analyze-RagMetadata.ps1** - Summarizes RAG usage metadata from JSON and reports statistics plus field frequencies.
-- **AnalyzeOrchestraLog.ps1** - Parses Orchestra log files, groups warning/error entries, summarizes first/last occurrence and count, and supports regex-based normalization rules for grouping.
+- **Analyze-OrchestraLog.ps1** - Parses Orchestra log files, groups warning/error entries, summarizes first/last occurrence and count, and supports regex-based normalization rules for grouping.
 - **Extract-ChatProperties.ps1** - Selects specific chat metadata fields and outputs a simplified JSON file.
 - **Start-HttpListener.ps1** - Runs a lightweight HTTP/HTTPS listener that logs inbound requests.
 - **Test-Connections.ps1** - Checks TCP connectivity for CSV-listed hosts and records results with resolved IPs.

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -185,7 +185,7 @@ When the current commit is not directly tagged, the status column shows the most
 
 ## Orchestra log analysis notes
 
-`AnalyzeOrchestraLog` parses Orchestra server log entries and groups recurring warning/error statements across one or more log files.
+`Analyze-OrchestraLog` parses Orchestra server log entries and groups recurring warning/error statements across one or more log files.
 For grouping stability, the script supports a settings file with `regex;replacement` normalization rules that are applied before aggregation.
 The summary output tracks first/last occurrence, count, severity, flattened statement text, and the first stacktrace line.
 

--- a/Scripts/Analyze-OrchestraLog/Analyze-OrchestraLog.ps1
+++ b/Scripts/Analyze-OrchestraLog/Analyze-OrchestraLog.ps1
@@ -21,10 +21,10 @@
     Severity levels to include in the result (for example WARNING, SEVERE, ERROR).
 
 .EXAMPLE
-    .\AnalyzeOrchestraLog.ps1 -LogPath ".\server.log"
+    .\Analyze-OrchestraLog.ps1 -LogPath ".\server.log"
 
 .EXAMPLE
-    .\AnalyzeOrchestraLog.ps1 -LogPath ".\logs\*.log" -OutputDirectory ".\out" -SettingsFile ".\normalize.txt"
+    .\Analyze-OrchestraLog.ps1 -LogPath ".\logs\*.log" -OutputDirectory ".\out" -SettingsFile ".\normalize.txt"
 #>
 [CmdletBinding()]
 param (
@@ -308,8 +308,8 @@ if (-not [string]::IsNullOrWhiteSpace($OutputDirectory)) {
     New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 
     $stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $csvPath = Join-Path -Path $OutputDirectory -ChildPath "AnalyzeOrchestraLog_$($stamp).csv"
-    $txtPath = Join-Path -Path $OutputDirectory -ChildPath "AnalyzeOrchestraLog_$($stamp).txt"
+    $csvPath = Join-Path -Path $OutputDirectory -ChildPath "Analyze-OrchestraLog_$($stamp).csv"
+    $txtPath = Join-Path -Path $OutputDirectory -ChildPath "Analyze-OrchestraLog_$($stamp).txt"
 
     $summary | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     $summary | Format-Table -AutoSize | Out-String | Set-Content -Path $txtPath -Encoding UTF8


### PR DESCRIPTION
### Motivation
- Standardize the script naming to a hyphenated form and keep documentation and generated outputs consistent with the new script name.

### Description
- Renamed the script folder and file to `Scripts/Analyze-OrchestraLog/Analyze-OrchestraLog.ps1`, updated in-file usage examples and the output filename prefixes to `Analyze-OrchestraLog_...`, and updated references in `README.md` and `ScenarioInfo.md`.

### Testing
- Verified the script file is accessible with `pwsh -NoProfile -Command "Get-ChildItem Scripts/Analyze-OrchestraLog/Analyze-OrchestraLog.ps1 | Out-Null; 'ok'"`, confirmed no remaining `AnalyzeOrchestraLog` occurrences with `rg`, and checked repository status with `git status --short`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998149daec8833398ce3ea48ca528eb)