### PR TITLE
Add Write-ElasticDataToDatabase with SQL Server schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Validate-Scenarios.ps1** - Validates scenario folders (including a direct path to a single scenario folder) or PSC archives with optional mode/category/name filters, shows validation progress, and can write a text report; derives channel strategy from `numberOfInstances`, skips ST checks for selected channel root types, and allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
+- **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields into SQL Server.
 
 ## Shared utilities
 
-- **Scripts/Common/ElasticSearchHelpers.ps1** - Hosts `Invoke-ElasticScrollSearch`, a reusable helper that issues scroll queries, aggregates all hits, surfaces detailed error information, and optionally reports page progress for callers. Scripts such as Process-MissingMedarchiv and Evaluate-OrchestraErrorsViaElastic dot-source this file to keep Elasticsearch pagination logic consistent.
+- **Scripts/Common/ElasticSearchHelpers.ps1** - Hosts `Invoke-ElasticScrollSearch`, a reusable helper that issues scroll queries, aggregates all hits, surfaces detailed error information, and optionally reports page progress for callers. Scripts such as Process-MissingMedarchiv, Evaluate-OrchestraErrorsViaElastic, and Write-ElasticDataToDatabase dot-source this file to keep Elasticsearch pagination logic consistent.
 
 ## Documentation references
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -178,6 +178,10 @@ This keeps local runtime files out of `git status` without requiring repository-
 Pending-change summaries show short counts for tracked (`c`) and untracked (`u`) files and now also show update availability when both states apply.
 When the current commit is not directly tagged, the status column shows the most recent reachable tag in parentheses.
 
+## Elastic export script notes
+
+`Write-ElasticDataToDatabase` reads paged Elasticsearch results via the shared helper and stores selected SUBFL process/business-key fields in SQL Server. The SQL companion file creates `[dbo].[ElasticData]` with both text and XML storage for `BK.SUBFL_subid_list` to support future query scenarios.
+
 ## Script parameter conventions
 - Repository scripts that expose both `StartDate` and `EndDate` can also accept `Timespan` as an alternative end-bound.
 - `Timespan` accepts numeric minute values and PowerShell `TimeSpan` values.

--- a/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.ps1
+++ b/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.ps1
@@ -1,0 +1,248 @@
+<#
+.SYNOPSIS
+    Reads SUBFL data from Elasticsearch and writes it into SQL Server.
+
+.DESCRIPTION
+    Queries Elasticsearch with date, instance, and ScenarioName filters, using the
+    shared Invoke-ElasticScrollSearch helper for paged retrieval. For each hit, the
+    script extracts MSGID/BusinessCaseId, scenario/process fields, and selected
+    SUBFL business key values and writes them to dbo.ElasticData in SQL Server.
+
+    The BK.SUBFL_subid_list value is normalized to a comma-separated string and also
+    transformed into XML (<subids><subid>...</subid></subids>) for future SQL queries.
+
+.PARAMETER StartDate
+    Inclusive start date for @timestamp filtering.
+
+.PARAMETER EndDate
+    Inclusive end date for @timestamp filtering.
+
+.PARAMETER Instance
+    Optional Orchestra instance filter.
+
+.PARAMETER ScenarioName
+    ScenarioName wildcard filter (for example SUBFL*).
+
+.PARAMETER Database
+    SQL Server target database name. Defaults to ElasticData.
+
+.PARAMETER Server
+    SQL Server target server name. Defaults to evolux.wienkav.at.
+
+.PARAMETER ElasticUrl
+    Elasticsearch _search URL.
+
+.PARAMETER ElasticApiKey
+    Optional Elasticsearch API key.
+
+.PARAMETER ElasticApiKeyPath
+    Optional path to a file containing the Elasticsearch API key.
+
+.EXAMPLE
+    ./Write-ElasticDataToDatabase.ps1 -StartDate (Get-Date).Date -EndDate (Get-Date) -ScenarioName 'SUBFL*'
+#>
+param(
+    [Parameter(Mandatory=$true)]
+    [datetime]$StartDate,
+
+    [Parameter(Mandatory=$true)]
+    [datetime]$EndDate,
+
+    [Parameter(Mandatory=$false)]
+    [string]$Instance,
+
+    [Parameter(Mandatory=$true)]
+    [string]$ScenarioName,
+
+    [Parameter(Mandatory=$false)]
+    [string]$Database = 'ElasticData',
+
+    [Parameter(Mandatory=$false)]
+    [string]$Server = 'evolux.wienkav.at',
+
+    [Parameter(Mandatory=$false)]
+    [string]$ElasticUrl = 'https://es-obs.apps.zeus.wien.at/logs-orchestra.journals*/_search',
+
+    [Parameter(Mandatory=$false)]
+    [string]$ElasticApiKey,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ElasticApiKeyPath = (Join-Path -Path $PSScriptRoot -ChildPath 'elastic.key')
+)
+
+$sharedHelpersDirectory = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'Common'
+$sharedHelpersPath = Join-Path -Path $sharedHelpersDirectory -ChildPath 'ElasticSearchHelpers.ps1'
+if (-not (Test-Path -Path $sharedHelpersPath)) {
+    throw "Shared Elastic helper not found at '$sharedHelpersPath'."
+}
+. $sharedHelpersPath
+
+function ConvertTo-StringValue {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [string]) { return $Value }
+    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+        $parts = @()
+        foreach ($entry in $Value) {
+            if ($null -eq $entry) { continue }
+            $parts += "$entry"
+        }
+        return [string]::Join(',', $parts)
+    }
+
+    return "$Value"
+}
+
+function ConvertTo-SubIdListXml {
+    param([string]$SubIdList)
+
+    if ([string]::IsNullOrWhiteSpace($SubIdList)) {
+        return '<subids />'
+    }
+
+    $subIds = $SubIdList.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    if ($subIds.Count -eq 0) {
+        return '<subids />'
+    }
+
+    $xmlBuilder = [System.Text.StringBuilder]::new()
+    $null = $xmlBuilder.Append('<subids>')
+    foreach ($subId in $subIds) {
+        $escaped = [System.Security.SecurityElement]::Escape($subId)
+        $null = $xmlBuilder.Append("<subid>$escaped</subid>")
+    }
+    $null = $xmlBuilder.Append('</subids>')
+    return $xmlBuilder.ToString()
+}
+
+$headers = @{}
+if (-not [string]::IsNullOrWhiteSpace($ElasticApiKey)) {
+    $headers['Authorization'] = "ApiKey $ElasticApiKey"
+} elseif ($ElasticApiKeyPath -and (Test-Path -Path $ElasticApiKeyPath)) {
+    $apiKeyFromFile = (Get-Content -Path $ElasticApiKeyPath -Raw).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($apiKeyFromFile)) {
+        $headers['Authorization'] = "ApiKey $apiKeyFromFile"
+    }
+}
+
+$filters = @(
+    @{ range = @{ '@timestamp' = @{ gte = $StartDate.ToString('o'); lte = $EndDate.ToString('o') } } },
+    @{ wildcard = @{ 'ScenarioName' = @{ value = $ScenarioName } } }
+)
+
+if (-not [string]::IsNullOrWhiteSpace($Instance)) {
+    $filters += @{ term = @{ 'Instance' = $Instance } }
+}
+
+$body = @{
+    size = 1000
+    query = @{ bool = @{ filter = $filters } }
+    _source = @(
+        '@timestamp',
+        'BusinessCaseId',
+        'MSGID',
+        'ScenarioName',
+        'ProcessName',
+        'BK.SUBFL_category',
+        'BK.SUBFL_subcategory',
+        'BK._HCMMSGEVENT',
+        'BK.SUBFL_subid',
+        'BK.SUBFL_subid_list'
+    )
+}
+
+$script:pageCount = 0
+$pageProgress = {
+    param($PageNumber, $PageHits, $TotalCollected)
+
+    $script:pageCount = $PageNumber
+    Write-Progress -Id 1 -Activity 'Loading Elasticsearch data' -Status "Page $($PageNumber) - collected $($TotalCollected)" -PercentComplete 0
+}
+
+Write-Host 'Querying Elasticsearch...'
+$hits = Invoke-ElasticScrollSearch -ElasticUrl $ElasticUrl -Body $body -Headers $headers -TimeoutSec 120 -OnPage $pageProgress
+Write-Progress -Id 1 -Activity 'Loading Elasticsearch data' -Completed
+
+if (-not $hits -or $hits.Count -eq 0) {
+    Write-Host 'No Elasticsearch hits found for the given filter.'
+    return
+}
+
+$table = [System.Data.DataTable]::new()
+$null = $table.Columns.Add('MSGID', [string])
+$null = $table.Columns.Add('ScenarioName', [string])
+$null = $table.Columns.Add('ProcessName', [string])
+$null = $table.Columns.Add('ProcesssStarted', [string])
+$null = $table.Columns.Add('BK_SUBFL_category', [string])
+$null = $table.Columns.Add('BK_SUBFL_subcategory', [string])
+$null = $table.Columns.Add('BK_HCMMSGEVENT', [string])
+$null = $table.Columns.Add('BK_SUBFL_subid', [string])
+$null = $table.Columns.Add('BK_SUBFL_subid_list', [string])
+$null = $table.Columns.Add('BK_SUBFL_subid_list_xml', [string])
+
+$totalHits = $hits.Count
+for ($index = 0; $index -lt $totalHits; $index++) {
+    $hit = $hits[$index]
+    $source = $hit._source
+
+    $msgId = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'MSGID')
+    if ([string]::IsNullOrWhiteSpace($msgId)) {
+        $msgId = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BusinessCaseId')
+    }
+
+    $scenario = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'ScenarioName')
+    $processName = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'ProcessName')
+    $processStarted = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath '@timestamp')
+    $category = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_category')
+    $subCategory = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_subcategory')
+    $hcmMsgEvent = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK._HCMMSGEVENT')
+    $subId = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_subid')
+
+    $subIdListRaw = Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_subid_list'
+    $subIdList = ConvertTo-StringValue $subIdListRaw
+    $subIdListXml = ConvertTo-SubIdListXml -SubIdList $subIdList
+
+    $row = $table.NewRow()
+    $row['MSGID'] = $msgId
+    $row['ScenarioName'] = $scenario
+    $row['ProcessName'] = $processName
+    $row['ProcesssStarted'] = $processStarted
+    $row['BK_SUBFL_category'] = $category
+    $row['BK_SUBFL_subcategory'] = $subCategory
+    $row['BK_HCMMSGEVENT'] = $hcmMsgEvent
+    $row['BK_SUBFL_subid'] = $subId
+    $row['BK_SUBFL_subid_list'] = $subIdList
+    $row['BK_SUBFL_subid_list_xml'] = $subIdListXml
+    $null = $table.Rows.Add($row)
+
+    $percent = [int]((($index + 1) / [Math]::Max(1, $totalHits)) * 100)
+    Write-Progress -Id 2 -Activity 'Transforming Elasticsearch hits' -Status "Record $($index + 1) / $($totalHits)" -PercentComplete $percent
+}
+Write-Progress -Id 2 -Activity 'Transforming Elasticsearch hits' -Completed
+
+$connectionString = "Server=$($Server);Database=$($Database);Integrated Security=True;TrustServerCertificate=True;"
+$connection = [System.Data.SqlClient.SqlConnection]::new($connectionString)
+$bulkCopy = $null
+
+try {
+    $connection.Open()
+
+    $bulkCopy = [System.Data.SqlClient.SqlBulkCopy]::new($connection)
+    $bulkCopy.DestinationTableName = '[dbo].[ElasticData]'
+    $bulkCopy.BatchSize = 2000
+    $bulkCopy.BulkCopyTimeout = 0
+
+    foreach ($column in $table.Columns) {
+        $null = $bulkCopy.ColumnMappings.Add($column.ColumnName, $column.ColumnName)
+    }
+
+    Write-Host "Writing $($table.Rows.Count) rows to [$($Database)].[dbo].[ElasticData] on $($Server)..."
+    $bulkCopy.WriteToServer($table)
+    Write-Host 'Finished writing rows to SQL Server.'
+}
+finally {
+    if ($bulkCopy) { $bulkCopy.Close() }
+    if ($connection.State -ne [System.Data.ConnectionState]::Closed) { $connection.Close() }
+    $connection.Dispose()
+}

--- a/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.sql
+++ b/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.sql
@@ -1,0 +1,25 @@
+IF OBJECT_ID(N'[dbo].[ElasticData]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [dbo].[ElasticData]
+    (
+        [Id] BIGINT IDENTITY(1,1) NOT NULL,
+        [MSGID] NVARCHAR(200) NULL,
+        [ScenarioName] NVARCHAR(400) NULL,
+        [ProcessName] NVARCHAR(400) NULL,
+        [ProcesssStarted] NVARCHAR(64) NULL,
+        [BK_SUBFL_category] NVARCHAR(200) NULL,
+        [BK_SUBFL_subcategory] NVARCHAR(200) NULL,
+        [BK_HCMMSGEVENT] NVARCHAR(200) NULL,
+        [BK_SUBFL_subid] NVARCHAR(200) NULL,
+        [BK_SUBFL_subid_list] NVARCHAR(MAX) NULL,
+        [BK_SUBFL_subid_list_xml] XML NULL,
+        CONSTRAINT [PK_ElasticData] PRIMARY KEY CLUSTERED ([Id] ASC)
+    );
+END;
+GO
+
+CREATE INDEX [IX_ElasticData_MSGID] ON [dbo].[ElasticData]([MSGID]);
+GO
+
+CREATE INDEX [IX_ElasticData_ScenarioName_ProcesssStarted] ON [dbo].[ElasticData]([ScenarioName], [ProcesssStarted]);
+GO

--- a/SubflElasticInfo.md
+++ b/SubflElasticInfo.md
@@ -44,3 +44,17 @@ The different CASENO values (`BK._CASENO`, `BK._CASENO_BC`, and `BK._CASENO_ISH`
 - SUBFL scripts in this repository that expose `StartDate`/`EndDate` also accept `Timespan` as an alternative to `EndDate`.
 - `Timespan` supports either a numeric minute value or a PowerShell `TimeSpan` input.
 - If neither `EndDate` nor `Timespan` is provided, the scripts apply a default range of 15 minutes from `StartDate`.
+
+## SQL export field set
+
+`Write-ElasticDataToDatabase` exports a subset of SUBFL fields into SQL Server for downstream analysis:
+
+- `MSGID` (fallback: `BusinessCaseId`)
+- `ScenarioName`
+- `ProcessName`
+- `@timestamp` (stored as `ProcesssStarted`)
+- `BK.SUBFL_category`
+- `BK.SUBFL_subcategory`
+- `BK._HCMMSGEVENT`
+- `BK.SUBFL_subid`
+- `BK.SUBFL_subid_list` (stored both as comma-separated text and as XML `<subids><subid>...</subid></subids>`)


### PR DESCRIPTION
### Motivation
- Provide a reusable tool to extract SUBFL records from Elasticsearch into SQL Server for downstream analysis and ad-hoc queries. 
- Preserve SUBFL subscription identifiers both as delimited text and as XML to support future XML/XPath-based queries in SQL Server.
- Reuse the centralized Elasticsearch paging helper and progress UI so extraction behaviour matches other SUBFL scripts.

### Description
- Add `Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.ps1`, a PowerShell script that accepts `StartDate`, `EndDate`, `Instance`, `ScenarioName`, `Database`, and `Server` and uses `Invoke-ElasticScrollSearch` with `Write-Progress` callbacks to fetch paged results. 
- Extract and normalize fields as strings including `MSGID` (with fallback to `BusinessCaseId`), `ScenarioName`, `ProcessName`, `@timestamp` (stored as `ProcesssStarted`), `BK.SUBFL_category`, `BK.SUBFL_subcategory`, `BK._HCMMSGEVENT`, `BK.SUBFL_subid`, and `BK.SUBFL_subid_list`, and convert `BK.SUBFL_subid_list` into XML via `ConvertTo-SubIdListXml`. 
- Bulk-write results into SQL Server using `System.Data.SqlClient.SqlBulkCopy` targeting table `[dbo].[ElasticData]` and include column mappings for the generated columns. 
- Add a companion SQL file `Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.sql` with a SQL Server 2016-compatible `CREATE TABLE` (including `XML` column `BK_SUBFL_subid_list_xml`) and useful indexes. 
- Update `README.md`, `SubflElasticInfo.md`, and `ScenarioInfo.md` to document the new script and the exported field set and to note the shared helper usage.

### Testing
- Verified the new script parses by running `pwsh -NoProfile -Command "[void][scriptblock]::Create((Get-Content -Raw 'Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.ps1')); 'OK'"`, which returned `OK` (success). 
- Confirmed repository files and documentation were updated and `git status --short` reported no uncommitted changes after staging (no outstanding modifications).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69985a260d648333918efad87cc61590)