### PR TITLE
Default SUBFL wildcard and export BK.SUBFL_changeart in Write-ElasticDataToDatabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Validate-Scenarios.ps1** - Validates scenario folders (including a direct path to a single scenario folder) or PSC archives with optional mode/category/name filters, shows validation progress, and can write a text report; derives channel strategy from `numberOfInstances`, skips ST checks for selected channel root types, and allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
-- **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields into SQL Server.
+- **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -180,7 +180,7 @@ When the current commit is not directly tagged, the status column shows the most
 
 ## Elastic export script notes
 
-`Write-ElasticDataToDatabase` reads paged Elasticsearch results via the shared helper and stores selected SUBFL process/business-key fields in SQL Server. The SQL companion file creates `[dbo].[ElasticData]` with both text and XML storage for `BK.SUBFL_subid_list` to support future query scenarios.
+`Write-ElasticDataToDatabase` reads paged Elasticsearch results via the shared helper and stores selected SUBFL process/business-key fields in SQL Server. It defaults the ScenarioName wildcard to `*SUBFL*` and includes `BK.SUBFL_changeart` in the export. The SQL companion file creates `[dbo].[ElasticData]` with both text and XML storage for `BK.SUBFL_subid_list` to support future query scenarios.
 
 ## Script parameter conventions
 - Repository scripts that expose both `StartDate` and `EndDate` can also accept `Timespan` as an alternative end-bound.

--- a/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.ps1
+++ b/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.ps1
@@ -21,7 +21,7 @@
     Optional Orchestra instance filter.
 
 .PARAMETER ScenarioName
-    ScenarioName wildcard filter (for example SUBFL*).
+    ScenarioName wildcard filter. Defaults to *SUBFL*.
 
 .PARAMETER Database
     SQL Server target database name. Defaults to ElasticData.
@@ -39,7 +39,7 @@
     Optional path to a file containing the Elasticsearch API key.
 
 .EXAMPLE
-    ./Write-ElasticDataToDatabase.ps1 -StartDate (Get-Date).Date -EndDate (Get-Date) -ScenarioName 'SUBFL*'
+    ./Write-ElasticDataToDatabase.ps1 -StartDate (Get-Date).Date -EndDate (Get-Date)
 #>
 param(
     [Parameter(Mandatory=$true)]
@@ -51,8 +51,8 @@ param(
     [Parameter(Mandatory=$false)]
     [string]$Instance,
 
-    [Parameter(Mandatory=$true)]
-    [string]$ScenarioName,
+    [Parameter(Mandatory=$false)]
+    [string]$ScenarioName = '*SUBFL*',
 
     [Parameter(Mandatory=$false)]
     [string]$Database = 'ElasticData',
@@ -144,6 +144,7 @@ $body = @{
         'MSGID',
         'ScenarioName',
         'ProcessName',
+        'BK.SUBFL_changeart',
         'BK.SUBFL_category',
         'BK.SUBFL_subcategory',
         'BK._HCMMSGEVENT',
@@ -174,6 +175,7 @@ $null = $table.Columns.Add('MSGID', [string])
 $null = $table.Columns.Add('ScenarioName', [string])
 $null = $table.Columns.Add('ProcessName', [string])
 $null = $table.Columns.Add('ProcesssStarted', [string])
+$null = $table.Columns.Add('BK_SUBFL_changeart', [string])
 $null = $table.Columns.Add('BK_SUBFL_category', [string])
 $null = $table.Columns.Add('BK_SUBFL_subcategory', [string])
 $null = $table.Columns.Add('BK_HCMMSGEVENT', [string])
@@ -194,6 +196,7 @@ for ($index = 0; $index -lt $totalHits; $index++) {
     $scenario = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'ScenarioName')
     $processName = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'ProcessName')
     $processStarted = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath '@timestamp')
+    $changeArt = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_changeart')
     $category = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_category')
     $subCategory = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK.SUBFL_subcategory')
     $hcmMsgEvent = ConvertTo-StringValue (Get-ElasticSourceValue -Source $source -FieldPath 'BK._HCMMSGEVENT')
@@ -208,6 +211,7 @@ for ($index = 0; $index -lt $totalHits; $index++) {
     $row['ScenarioName'] = $scenario
     $row['ProcessName'] = $processName
     $row['ProcesssStarted'] = $processStarted
+    $row['BK_SUBFL_changeart'] = $changeArt
     $row['BK_SUBFL_category'] = $category
     $row['BK_SUBFL_subcategory'] = $subCategory
     $row['BK_HCMMSGEVENT'] = $hcmMsgEvent

--- a/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.sql
+++ b/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.sql
@@ -7,6 +7,7 @@ BEGIN
         [ScenarioName] NVARCHAR(400) NULL,
         [ProcessName] NVARCHAR(400) NULL,
         [ProcesssStarted] NVARCHAR(64) NULL,
+        [BK_SUBFL_changeart] NVARCHAR(200) NULL,
         [BK_SUBFL_category] NVARCHAR(200) NULL,
         [BK_SUBFL_subcategory] NVARCHAR(200) NULL,
         [BK_HCMMSGEVENT] NVARCHAR(200) NULL,
@@ -15,6 +16,13 @@ BEGIN
         [BK_SUBFL_subid_list_xml] XML NULL,
         CONSTRAINT [PK_ElasticData] PRIMARY KEY CLUSTERED ([Id] ASC)
     );
+END;
+GO
+
+IF COL_LENGTH('dbo.ElasticData', 'BK_SUBFL_changeart') IS NULL
+BEGIN
+    ALTER TABLE [dbo].[ElasticData]
+    ADD [BK_SUBFL_changeart] NVARCHAR(200) NULL;
 END;
 GO
 

--- a/SubflElasticInfo.md
+++ b/SubflElasticInfo.md
@@ -53,6 +53,7 @@ The different CASENO values (`BK._CASENO`, `BK._CASENO_BC`, and `BK._CASENO_ISH`
 - `ScenarioName`
 - `ProcessName`
 - `@timestamp` (stored as `ProcesssStarted`)
+- `BK.SUBFL_changeart`
 - `BK.SUBFL_category`
 - `BK.SUBFL_subcategory`
 - `BK._HCMMSGEVENT`


### PR DESCRIPTION
### Motivation
- Make SUBFL exports easier to run by defaulting the `ScenarioName` filter to `*SUBFL*` and add the SUBFL change type to the export so downstream consumers can see `INSERT`/`UPDATE`/`DELETE` semantics.

### Description
- Make the `ScenarioName` parameter optional and default it to `'*SUBFL*'`, and update the script help/example accordingly.
- Add `BK.SUBFL_changeart` to the Elasticsearch `_source`, extract it during transformation, add a `BK_SUBFL_changeart` column to the in-memory `DataTable`, and map it into the SQL bulk copy rows.
- Extend the SQL companion script to include `[BK_SUBFL_changeart]` in new table creation and run a conditional `ALTER TABLE` to add the column for existing databases.
- Update `README.md`, `ScenarioInfo.md`, and `SubflElasticInfo.md` to document the new default filter and exported `BK.SUBFL_changeart` field.

### Testing
- Ran a PowerShell parser check via `pwsh -NoProfile -File /tmp/parse_check.ps1`, which reported `Parse OK` indicating the modified script parses correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69985f49f80c83338efe9d3f4cf4ba56)