### PR TITLE
Add missing-process SQL queries for Write-ElasticDataToDatabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Validate-Scenarios.ps1** - Validates scenario folders (including a direct path to a single scenario folder) or PSC archives with optional mode/category/name filters, shows validation progress, and can write a text report; derives channel strategy from `numberOfInstances`, skips ST checks for selected channel root types, and allows sequential channel/mapping strategy when all process models in a scenario are sequential (ignores non-XML PSC entries).
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
-- **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server.
+- **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 
 ## Shared utilities
 

--- a/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.MissingProcesses.sql
+++ b/Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.MissingProcesses.sql
@@ -1,0 +1,76 @@
+/*
+    Missing process checks for dbo.ElasticData.
+
+    Input rows:
+      - MSGID is set
+      - BK_SUBFL_subid is empty/null
+
+    Output rows:
+      - MSGID is set
+      - BK_SUBFL_subid is set
+
+    Expected outputs per MSGID are read from BK_SUBFL_subid_list_xml.
+*/
+
+;WITH InputRows AS
+(
+    SELECT DISTINCT
+        ed.MSGID,
+        ed.BK_SUBFL_subid_list,
+        ed.BK_SUBFL_subid_list_xml
+    FROM dbo.ElasticData ed
+    WHERE ed.MSGID IS NOT NULL
+      AND LTRIM(RTRIM(ed.MSGID)) <> ''
+      AND (ed.BK_SUBFL_subid IS NULL OR LTRIM(RTRIM(ed.BK_SUBFL_subid)) = '')
+),
+ExpectedOutput AS
+(
+    SELECT
+        i.MSGID,
+        expectedSubId = LTRIM(RTRIM(x.value('(.)[1]', 'nvarchar(200)')))
+    FROM InputRows i
+    CROSS APPLY i.BK_SUBFL_subid_list_xml.nodes('/subids/subid') AS s(x)
+),
+ActualOutput AS
+(
+    SELECT DISTINCT
+        ed.MSGID,
+        actualSubId = LTRIM(RTRIM(ed.BK_SUBFL_subid))
+    FROM dbo.ElasticData ed
+    WHERE ed.MSGID IS NOT NULL
+      AND LTRIM(RTRIM(ed.MSGID)) <> ''
+      AND ed.BK_SUBFL_subid IS NOT NULL
+      AND LTRIM(RTRIM(ed.BK_SUBFL_subid)) <> ''
+)
+
+-- a) Missing all outputs: input exists, but there is no output row at all for the MSGID.
+SELECT
+    i.MSGID,
+    i.BK_SUBFL_subid_list AS expected_subid_list
+FROM InputRows i
+LEFT JOIN ActualOutput a
+    ON a.MSGID = i.MSGID
+WHERE a.MSGID IS NULL
+ORDER BY i.MSGID;
+
+-- b) Missing some outputs: outputs exist, but not all expected subids are present.
+SELECT
+    i.MSGID,
+    i.BK_SUBFL_subid_list AS expected_subid_list,
+    missing_subids = STRING_AGG(CASE WHEN a2.actualSubId IS NULL THEN e.expectedSubId END, ',') WITHIN GROUP (ORDER BY e.expectedSubId),
+    existing_output_count = COUNT(DISTINCT a2.actualSubId),
+    expected_output_count = COUNT(DISTINCT e.expectedSubId)
+FROM InputRows i
+INNER JOIN ActualOutput a
+    ON a.MSGID = i.MSGID
+INNER JOIN ExpectedOutput e
+    ON e.MSGID = i.MSGID
+LEFT JOIN ActualOutput a2
+    ON a2.MSGID = e.MSGID
+   AND a2.actualSubId = e.expectedSubId
+WHERE e.expectedSubId <> ''
+GROUP BY
+    i.MSGID,
+    i.BK_SUBFL_subid_list
+HAVING COUNT(DISTINCT a2.actualSubId) < COUNT(DISTINCT e.expectedSubId)
+ORDER BY i.MSGID;

--- a/SubflElasticInfo.md
+++ b/SubflElasticInfo.md
@@ -59,3 +59,5 @@ The different CASENO values (`BK._CASENO`, `BK._CASENO_BC`, and `BK._CASENO_ISH`
 - `BK._HCMMSGEVENT`
 - `BK.SUBFL_subid`
 - `BK.SUBFL_subid_list` (stored both as comma-separated text and as XML `<subids><subid>...</subid></subids>`)
+
+For downstream completeness checks, use `Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.MissingProcesses.sql` to identify MSGIDs with no outputs and MSGIDs with only partial outputs compared to `BK_SUBFL_subid_list`.


### PR DESCRIPTION
### Motivation
- Provide a simple SQL-based completeness check for SUBFL flows written into `dbo.ElasticData` to detect MSGIDs where output records are wholly or partially missing compared to the expected `BK_SUBFL_subid_list`.
- Make downstream diagnostics easier by exposing both "no outputs at all" and "partial outputs only" cases so teams can triage missing subscription outputs.

### Description
- Added `Scripts/Write-ElasticDataToDatabase/Write-ElasticDataToDatabase.MissingProcesses.sql` which defines two queries: (a) finds MSGIDs that have input rows with no output rows, and (b) finds MSGIDs where outputs exist but some expected `subid`s from `BK_SUBFL_subid_list_xml` are missing, returning missing subids and counts.
- The partial-output query derives expected subids from `BK_SUBFL_subid_list_xml.nodes('/subids/subid')` and computes `missing_subids` via `STRING_AGG(CASE WHEN a2.actualSubId IS NULL THEN e.expectedSubId END, ',')`.
- Updated `README.md` and `SubflElasticInfo.md` to document the new SQL template and point users to the missing-process check file.

### Testing
- Verified the new SQL file contents with `sed -n` and `nl` to confirm both queries are present and correctly reference `BK_SUBFL_subid_list_xml`, which succeeded.
- Confirmed references to the new templates were added using `rg` and inspected `README.md` and `SubflElasticInfo.md` snippets, which succeeded.
- Performed a `git commit` for the change and validated the resulting commit/summary via `git log` and `git show`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69986138e6a88333b8d39f2c4e234b63)