### PR TITLE
Add basic PowerShell syntax validation guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,9 @@
   When a variable is followed immediately by characters like :, ., -, [, etc., always wrap the variable using sub-expression syntax:
   $($x): 1
   This applies especially inside hash literals and interpolated strings. Always use $($var) when the parser would otherwise misinterpret the variable boundary.
+
+## Basic script validation
+
+- Always run a basic PowerShell command check after script updates to catch syntax issues early, for example:
+  `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"`
   


### PR DESCRIPTION
### Motivation
- Provide a quick, reproducible check for contributors to catch PowerShell script syntax or resolution errors immediately after edits.

### Description
- Add a new `Basic script validation` section to `AGENTS.md` that documents running a simple command to validate a script, including the example: `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"`.

### Testing
- Ran the documented command `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` and it returned `ok`, indicating successful command resolution and no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d568c48b483338adf41a5a386e3e3)