### PR TITLE
Adjust Resend-FromElastic target mapping to Name/URL-only CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Transfer-OperationData.ps1** - Transfers DataStore rows into OrchestraOperationData using resumable batches.
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
-- **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch with flexible filters and supports grouped query reporting or controlled resend/test replay to configured HTTP targets.
+- **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch with flexible filters, offers grouped query reporting or controlled resend/test replay to configured HTTP targets, and tab-completes target names from `targets.csv`.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -196,5 +196,5 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Elastic resend operation notes
 
-`Resend-FromElastic` supports operational SUBFL replay workflows by querying Elasticsearch with stage/category/MSGID filters and replaying payloads in batch, all-at-once, or interactive single-step mode with keyboard controls (P/R/S/X). It can perform dry-run validation via `Action Test`, writes timestamped success/error logs, and can emit SourceInfo subscription filters through `TargetParty` and `TargetSubId`.
+`Resend-FromElastic` supports operational SUBFL replay workflows by querying Elasticsearch with stage/category/MSGID filters and replaying payloads in batch, all-at-once, or interactive single-step mode with keyboard controls (P/R/S/X). It can perform dry-run validation via `Action Test`, writes timestamped success/error logs, reads resend endpoint definitions from `targets.csv`, tab-completes `Target` values from CSV `Name` entries, and can emit SourceInfo subscription filters through `TargetParty` and `TargetSubId`.
 

--- a/Scripts/Resend-FromElastic/targets.csv
+++ b/Scripts/Resend-FromElastic/targets.csv
@@ -1,2 +1,2 @@
-Name,URL,Port
-PROD02-WSK,http://localhost,8080
+Name,URL
+PROD02-WSK,http://localhost:8080


### PR DESCRIPTION
### Motivation
- Simplify the target CSV contract so endpoint ports are carried in the `URL` field rather than a separate `Port` column to avoid mismatches between documentation and runtime behavior. 
- Ensure `Resend-FromElastic` resolves targets from a single canonical CSV format (`Name,URL`) and keeps tab-completion based on `Name` values. 

### Description
- Update the `-Target` parameter help text in `Scripts/Resend-FromElastic/Resend-FromElastic.ps1` to document `targets.csv` as `Name,URL` and note tab completion from `Name` entries. 
- Simplify `Resolve-TargetDefinition` to return the trimmed `URL` value directly and remove logic that appended a separate `Port` column. 
- Replace the sample `Scripts/Resend-FromElastic/targets.csv` with a two-column `Name,URL` example where non-default ports are embedded in the URL (e.g. `http://localhost:8080`). 

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` and it returned `ok`. 
- Verified tab completion via `TabExpansion2` with `pwsh -NoProfile -Command '$line = "./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 -Target PRO"; $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length; $res.CompletionMatches | Select-Object -ExpandProperty CompletionText'` which returned the expected `targets.csv` match (e.g. `PROD02-WSK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d57672ae48333bbc9b0b4a1ab7edc)