### PR TITLE
Colorize Resend-FromElastic console output

### DIFF
--- a/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
+++ b/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
@@ -222,7 +222,13 @@ function Write-RunLog {
 
     $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
     $line = "[$stamp] [$Level] $Message"
-    Write-Host $line
+    $levelColor = switch ($Level) {
+        'ERROR' { 'Red'; break }
+        'WARN' { 'Yellow'; break }
+        default { 'Gray'; break }
+    }
+
+    Write-Host $line -ForegroundColor $levelColor
     if ($script:LogFilePath) {
         Add-Content -Path $script:LogFilePath -Value $line
     }
@@ -682,10 +688,10 @@ for ($i = 0; $i -lt $records.Count; $i++) {
 
 Write-Progress -Id 2 -Activity 'Resend processing' -Completed
 Write-Host ''
-Write-Host 'Successes:'
-$script:SuccessLog | ForEach-Object { Write-Host $_ }
+Write-Host 'Successes:' -ForegroundColor Green
+$script:SuccessLog | ForEach-Object { Write-Host $_ -ForegroundColor Green }
 Write-Host ''
-Write-Host 'Errors:'
-$script:ErrorLog | ForEach-Object { Write-Host $_ }
+Write-Host 'Errors:' -ForegroundColor Red
+$script:ErrorLog | ForEach-Object { Write-Host $_ -ForegroundColor Red }
 Write-Host ''
 Write-RunLog -Level 'INFO' -Message "Finished. Successes: $($script:SuccessLog.Count), Errors: $($script:ErrorLog.Count)."


### PR DESCRIPTION
### Motivation
- Improve console readability by highlighting log levels and the final run summary so issues and successes are easier to scan. 
- Preserve existing file-based logging while making interactive output clearer for operators.

### Description
- Updated `Write-RunLog` to map log levels to console colors and call `Write-Host` with `-ForegroundColor` (`ERROR` => Red, `WARN` => Yellow, default => Gray) while leaving file logging unchanged. 
- Colorized the end-of-run summary so the `Successes:` header and entries are printed in green and the `Errors:` header and entries are printed in red. 
- Changes applied to `Scripts/Resend-FromElastic/Resend-FromElastic.ps1`.

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which completed successfully. 
- No automated tests failed during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d593dc0208333944f73a8420e52c8)