### PR TITLE
Normalize comma-separated array filters in Resend-FromElastic

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -196,5 +196,5 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Elastic resend operation notes
 
-`Resend-FromElastic` supports operational SUBFL replay workflows by querying Elasticsearch with stage/category/MSGID filters and replaying payloads in batch, all-at-once, or interactive single-step mode with keyboard controls (P/R/S/X). It can perform dry-run validation via `Action Test`, writes timestamped success/error logs, reads resend endpoint definitions from `targets.csv`, tab-completes `Target` values from CSV `Name` entries, and can emit SourceInfo subscription filters through `TargetParty` and `TargetSubId`.
+`Resend-FromElastic` supports operational SUBFL replay workflows by querying Elasticsearch with stage/category/MSGID filters and replaying payloads in batch, all-at-once, or interactive single-step mode with keyboard controls (P/R/S/X). It can perform dry-run validation via `Action Test`, writes timestamped success/error logs, reads resend endpoint definitions from `targets.csv`, tab-completes `Target` values from CSV `Name` entries, and can emit SourceInfo subscription filters through `TargetParty` and `TargetSubId`. Multi-value filter parameters also normalize comma-separated input into distinct values so array filters apply as Elasticsearch OR terms.
 


### PR DESCRIPTION
### Motivation
- Multi-value filter parameters such as `BusinessCaseId`, `CaseNo`, and `PatientId` were not handling comma-separated input correctly, causing attempts to supply multiple values as a single literal instead of an OR list. 
- The goal is to support both repeated parameter usage and comma-separated strings so callers can supply multiple filter values in either form. 
- Keep existing Elasticsearch `terms` queries (field-level OR semantics) while ensuring input is normalized into distinct values before query construction. 

### Description
- Added `Normalize-FilterValues` which splits comma-separated entries, trims whitespace, removes empty parts, and de-duplicates values. 
- Applied `Normalize-FilterValues` to all multi-value filter parameters early in the script (`CaseNo`, `PatientId`, `BusinessCaseId`, `Category`, `Subcategory`, `HcmMsgEvent`, `Instance`, `Environment`). 
- Left existing `ConvertTo-ElasticTermsFilter` and `terms` clauses unchanged so normalized arrays map to Elasticsearch `terms` queries (OR behavior per field). 
- Updated parameter help text for `CaseNo`, `PatientId`, and `BusinessCaseId`, and updated `ScenarioInfo.md` to document the comma-separated input normalization. 

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which returned `ok`, indicating the script loads without syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d658f13ac8333a3f21702e7a5e316)