### PR TITLE
Fix upstream tag label resolution in Handle-OrchestraGit

### DIFF
--- a/Scripts/Handle-OrchestraGit/Handle-OrchestraGit.ps1
+++ b/Scripts/Handle-OrchestraGit/Handle-OrchestraGit.ps1
@@ -263,8 +263,17 @@ function Get-UpstreamVersionLabel {
         return 'unknown'
     }
 
-    $tag = (& git -C $RepositoryPath describe --tags --exact-match $Reference 2>$null)
-    $tag = (""+$tag).Trim()
+    $exactTag = (& git -C $RepositoryPath describe --tags --exact-match $Reference 2>$null)
+    $tag = ("" + $exactTag).Trim()
+
+    if ([string]::IsNullOrWhiteSpace($tag)) {
+        $latestTag = (& git -C $RepositoryPath describe --tags --abbrev=0 $Reference 2>$null)
+        $latestTag = ("" + $latestTag).Trim()
+
+        if (-not [string]::IsNullOrWhiteSpace($latestTag)) {
+            $tag = "$($latestTag)*"
+        }
+    }
 
     if ([string]::IsNullOrWhiteSpace($tag)) {
         return $shortHash


### PR DESCRIPTION
### Motivation
- Upstream version labels were not shown when the upstream reference was not exactly on a tag, causing the status output to display only a short commit hash.

### Description
- Update `Get-UpstreamVersionLabel` in `Scripts/Handle-OrchestraGit/Handle-OrchestraGit.ps1` to first check for an exact tag via `git describe --tags --exact-match` and then fall back to the nearest reachable tag using `git describe --tags --abbrev=0` when no exact match exists.
- Format the fallback nearest tag as `<tag>*` and preserve the existing fallback to the short commit hash when no tags are available.
- Keep the returned label shape as `"<tag> <short-hash>"` or the short hash alone when appropriate.

### Testing
- Ran the basic PowerShell script validation `pwsh -NoProfile -Command "Get-Command ./Scripts/Handle-OrchestraGit/Handle-OrchestraGit.ps1 | Out-Null; 'ok'"` and it returned `ok`, indicating the script loads without syntax errors.
- No automated unit tests exist for this script; the change is limited to label resolution logic and validated by the load check above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d8432cb0c8333a6a7dfe1ed8d1192)