### PR TITLE
Update Resend-FromElastic intro to show runtime keystrokes

### DIFF
--- a/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
+++ b/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
@@ -213,6 +213,8 @@ if (-not (Test-Path -Path $sharedHelpersPath)) {
 }
 . $sharedHelpersPath
 
+Write-Host 'Key controls during processing: P=pause, R=resume/skip wait, S=single-step, X=stop.' -ForegroundColor Yellow
+
 $script:LogFilePath = $null
 $script:SuccessLog = [System.Collections.Generic.List[string]]::new()
 $script:ErrorLog = [System.Collections.Generic.List[string]]::new()


### PR DESCRIPTION
### Motivation
- Clarify interactive runtime controls for operators by surfacing the pause/resume/single/stop keystrokes at script startup.

### Description
- Replace the startup `Write-Host` line in `Scripts/Resend-FromElastic/Resend-FromElastic.ps1` with `Write-Host 'Key controls during processing: P=pause, R=resume/skip wait, S=single-step, X=stop.' -ForegroundColor Yellow` so the script prints the requested keys when loaded.

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which returned `ok` indicating the script is loadable and syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d8e9ec7d0833382c748741c224435)