### PR TITLE
Refine German Validate-Scenarios documentation based on review

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 
 - **SubflElasticInfo.md** - Overview of Subscription Flow (SUBFL) terminology plus how SUBFL scenarios log to Elasticsearch, including the specific fields and filters leveraged by the SUBFL-related scripts in this repository.
 - **ScenarioInfo.md** - Reference for Orchestra scenario folder structure, including expected file naming patterns and scenario-related configuration notes drawn from the scripts.
+- **Scripts/Validate-Scenarios/Validate-Scenarios.md** - German usage documentation for Validate-Scenarios, including defaults, exception handling, and review intent.
 
 ## Shared date-range behavior
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -161,6 +161,10 @@ When the script finds a non-default configuration that matches an exception code
 
 Validation now reports progress while scanning folder files and PSC archive entries.
 
+## Dedicated script usage documentation
+
+A dedicated German usage page for `Validate-Scenarios` is maintained next to the script at `Scripts/Validate-Scenarios/Validate-Scenarios.md`. It describes operational intent, default values, allowed alternatives, and exception documentation workflow for Confluence reuse.
+
 ## Orchestra git working copy notes
 
 Orchestra scenario working copies often contain local machine artifacts that should stay untracked.

--- a/Scripts/Validate-Scenarios/Validate-Scenarios.md
+++ b/Scripts/Validate-Scenarios/Validate-Scenarios.md
@@ -1,0 +1,150 @@
+# Validate-Scenarios – Anwendungsdokumentation
+
+## Zweck des Scripts
+
+`Validate-Scenarios.ps1` stellt sicher, dass Orchestra-Scenarios konsistent mit den definierten Standardwerten betrieben werden.
+Das Script existiert, um **Abweichungen sichtbar zu machen**, **Ausnahmen explizit zu dokumentieren** und damit eine bewusste Architektur-/Betriebsentscheidung zu erzwingen statt stiller, ungeprüfter Sonderfälle.
+
+Damit unterstützt es konkret:
+
+- technische Konsistenz über alle Scenarios,
+- nachvollziehbare Exceptions direkt in XML `description`-Feldern,
+- schnellere Reviews bei Änderungen an `ProcessModell_*`, `Channel_*` und `MessageMapping_*`.
+
+## Ablageort im Betrieb
+
+Der produktive Ablageort des Scripts ist:
+
+`\\vsma01.host.magwien.gv.at\ma01gat\GAT2\_Tools\Powershell\Validate-Scenarios.ps1`
+
+## Was wird validiert?
+
+Das Script validiert die Artefakttypen **ProcessModel**, **Channel** und **MessageMapping**.
+Die dazugehörigen Dateimuster sind:
+
+- ProcessModel-Dateien: `ProcessModell_*`
+- Channel-Dateien: `Channel_*`
+- MessageMapping-Dateien: `MessageMapping_*`
+
+Prüfkategorien (`ErrorCategories`):
+
+- `PM` (Process Mode)
+- `RS` (Redeployment Strategy)
+- `MR` (Manual Restart)
+- `SI` (Input Signal)
+- `BK` (Business Keys)
+- `ST` (Resource usage strategy für Channel/Mapping)
+
+## Pfadverhalten (`-Path`)
+
+`-Path` kann auf unterschiedliche Strukturen zeigen:
+
+- auf einen Root-Ordner mit vielen Scenario-Ordnern,
+- direkt auf **ein einzelnes Scenario-Verzeichnis**,
+- auf Strukturen mit **Sub-Sub-Foldern** innerhalb eines Scenarios (die relevanten XML-Dateien werden rekursiv gefunden).
+
+Zusätzlich kann über `-Filter` auf Scenario-Namen (Folder-Mode) oder PSC-Dateinamen (PSC-Mode) eingeschränkt werden.
+
+## Standardwerte (Defaults), Bedeutung und Alternativen
+
+Die folgenden Default-Entscheidungen sind die Referenz für „in line“-Scenarios.
+Abweichungen sind möglich, müssen aber als Exception dokumentiert werden.
+
+### Process Model
+
+- **PM default: `vr`** (`volatile with recovery`)
+  - `v`: `volatile` (ohne Recovery)
+  - `vr`: `volatile with recovery`
+  - `p`: `persistent`
+- **RS default: `r`** (`restart on redeploy`)
+  - `a`: `abort running processes`
+  - `r`: `restart after redeployment`
+- **MR default: `e`** (`manual restart enabled`)
+  - `e`: enabled
+  - `d`: disabled
+- **SI default: `p`** (`persistent signal subscription`)
+  - `p`: persistent subscription
+  - `t`: transient subscription
+- **BK default: `6`** (über Script-Parameter `MaxBusinessKeyCount`)
+  - mögliche Werte: positive Ganzzahlen (z. B. `6`, `8`, `10`)
+
+### Scheduling / Strategy
+
+- **SC default: `p`** (`parallel unbounded scheduling`)
+  - `p`: parallel unbounded
+  - `p#`: parallel mit Limit `#`
+  - `pg`: parallel grouped
+  - `s`: sequential
+  - `pi`: pipeline mode
+- **ST default: `p`** (`parallel execution`)
+  - `p`: parallel execution
+  - `s`: sequential execution
+
+Hinweise zur Herleitung von `ST`:
+
+- Bei `Channel_*` wird `ST` aus `numberOfInstances` abgeleitet (`1` => `s`, sonst `p`).
+- Bei `MessageMapping_*` wird `ST` aus `parallelExecution` abgeleitet (`false` => `s`, `true` => `p`).
+- Sequential `ST:s` bei Channel/Mapping ist zulässig, wenn **alle** Process Models des Scenarios sequential sind (`isFifo:true`, `isGroupedFifo:false`, `bestEffortLimit:0`, `pipelineMode:false`).
+
+## Script-Parameter (Usage)
+
+### Standardaufruf
+
+```powershell
+.\Scripts\Validate-Scenarios\Validate-Scenarios.ps1
+```
+
+### Wichtige Parameter
+
+- `-Path` (default `.`): Root-Ordner, einzelnes Scenario-Verzeichnis oder rekursiv zu scannender Bereich
+- `-Mode` (default `Folder`): `Folder` oder `PSC`
+- `-IncludePsc` (switch): prüft im `Folder`-Mode zusätzlich `.psc`
+- `-Filter` (default `all`): Wildcard auf Scenario-Ordner bzw. PSC-Dateien
+- `-ErrorCategories`: Teilmenge von `PM,RS,MR,SI,BK,ST`
+- `-MaxBusinessKeyCount` (default `6`): BK-Schwellwert
+- `-ShowExceptions` (switch): zeigt auch konfigurierte Ausnahmen
+- `-Output`: schreibt Report in Datei/Ordner
+
+### Beispielaufrufe
+
+```powershell
+# Alle Scenarios im Ordner prüfen
+.\Scripts\Validate-Scenarios\Validate-Scenarios.ps1 -Path D:\Scenarios
+
+# Direkt ein einzelnes Scenario-Verzeichnis prüfen
+.\Scripts\Validate-Scenarios\Validate-Scenarios.ps1 -Path D:\Scenarios\SUBFL_Import
+
+# Nur BK und ST prüfen, BK-Limit auf 8
+.\Scripts\Validate-Scenarios\Validate-Scenarios.ps1 -Path D:\Scenarios -ErrorCategories BK,ST -MaxBusinessKeyCount 8
+
+# Nur PSC-Dateien prüfen
+.\Scripts\Validate-Scenarios\Validate-Scenarios.ps1 -Path D:\Scenarios -Mode PSC
+```
+
+## Exceptions bewusst dokumentieren
+
+Ausnahmen werden im `description`-Feld der jeweiligen XML-Datei hinterlegt, z. B.:
+
+`PM:v; RS:a; ST:s; BK:8`
+
+Die `description` darf zusätzlich beliebigen Freitext enthalten; das Script liest nur die unterstützten Key/Value-Codes.
+
+Unterstützte Exception-Codes:
+
+- `PM`: `v`, `vr`, `p`
+- `RS`: `a`, `r`
+- `MR`: `e`, `d`
+- `SI`: `p`, `t`
+- `ST`: `p`, `s`
+- `BK`: numerischer Grenzwert
+
+Wichtig:
+
+- Nicht unterstützte oder fachlich nicht validierte Codes werden ignoriert.
+- Ziel ist, dass jede Abweichung vom Default eine nachvollziehbare, explizite Entscheidung bleibt.
+
+## Screenshots (Platzhalter)
+
+- [SCREENSHOT-1: Konsolen-Output ohne Exceptions]
+- [SCREENSHOT-2: Konsolen-Output mit `-ShowExceptions`]
+- [SCREENSHOT-3: Beispiel `description` mit Exception-Codes]


### PR DESCRIPTION
### Motivation

- Improve and clarify the German usage documentation for `Validate-Scenarios` so reviewers and operators have an unambiguous reference for defaults, allowed alternatives and exception handling.
- Address inline review comments to name validated artifact types, document path behaviour for nested folders and single scenario paths, and simplify invocation examples.

### Description

- Updated `Scripts/Validate-Scenarios/Validate-Scenarios.md` to explicitly name validated artifacts (`ProcessModel`, `Channel`, `MessageMapping`) and map them to filename patterns (`ProcessModell_*`, `Channel_*`, `MessageMapping_*`).
- Clarified `-Path` behaviour to state it may point to a root folder, a direct scenario directory, or nested sub-sub-folder structures and that relevant XML files are discovered recursively.
- Expanded the defaults and alternatives section to document meanings for `PM`, `RS`, `MR`, `SI`, `BK`, `SC`, and `ST`, and clarified how `ST` is derived for channels/mappings.
- Simplified usage examples to direct script invocation (`.\Scripts\Validate-Scenarios\Validate-Scenarios.ps1`), stated that `description` may contain arbitrary free text (the script only parses supported key/value tokens), and removed the previous team-workflow section.
- Added pointers to the new documentation from `README.md` and `ScenarioInfo.md` so the dedicated page is discoverable for Confluence reuse.

### Testing

- Ran the PowerShell sanity check `pwsh -NoProfile -Command "Get-Command ./Scripts/Validate-Scenarios/Validate-Scenarios.ps1 | Out-Null; 'ok'"` which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699da5df60e48333b256fc3b56da4eaa)