### PR TITLE
Add Python script to extract Cato units for Elastic ingestion and document Python-exception policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 - Update README.md if necessary, even if not asked for
 - Keep README.md script descriptions concise and consistent; avoid default values, color mentions, or overly detailed parameter listings.
 - Always add and maintain documentation at the top of a Powershell script
+- PowerShell remains the default script language unless explicitly requested otherwise.
+- Python script exceptions are allowed when explicitly requested and must use the `Python-` prefix for both folder and file names.
 - Keep SUBFL Elasticsearch context current in `SubflElasticInfo.md` when related scripts or knowledge change
 - Update `ScenarioInfo.md` when scripts or knowledge change
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MA01 PowerShell Scripts
 
-This repository contains a collection of PowerShell scripts used within the MA01 environment. Each script helps automate a specific operational or analysis task.
+This repository contains a collection of scripts used within the MA01 environment, primarily PowerShell. PowerShell is the default unless a different language is explicitly requested; Python exceptions use a `Python-` prefix for both folder and script file names.
 
 ## Scripts
 
@@ -23,6 +23,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, and writes newline-delimited JSON objects for Elasticsearch pickup.
 
 ## Shared utilities
 

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Python-ExtractCatoUnitsForElastic
+
+Connects to OrchEsbWskConfiguration, reads active Cato subscriptions,
+extracts all Condition values for locator="LST_KST", aggregates unit codes by
+Einrichtung (first up-to-4 leading digits), and writes newline-delimited JSON
+objects (not a JSON array) to an output file in the current working directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract LST_KST unit values from active Cato subscriptions and "
+            "write NDJSON grouped by Einrichtung."
+        )
+    )
+    parser.add_argument(
+        "--server",
+        default="orchestrasql.wienkav.at",
+        help="SQL Server host name.",
+    )
+    parser.add_argument(
+        "--database",
+        default="OrchEsbWskConfiguration",
+        help="SQL Server database name.",
+    )
+    parser.add_argument(
+        "--username",
+        default="Orchestra_Access_User",
+        help="SQL Server username.",
+    )
+    parser.add_argument(
+        "--password",
+        default="PASSWORD",
+        help="SQL Server password.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory where the output file is created.",
+    )
+    return parser.parse_args()
+
+
+def fetch_subscription_xmls(server: str, database: str, username: str, password: str) -> list[str]:
+    import pyodbc
+
+    connection_string = (
+        "Driver={ODBC Driver 18 for SQL Server};"
+        f"Server={server};"
+        f"Database={database};"
+        f"Uid={username};"
+        f"Pwd={password};"
+        "Encrypt=yes;"
+        "TrustServerCertificate=yes;"
+    )
+
+    query = """
+    select SubscriptionXml
+    from [dbo].[Subscription] s
+    inner join dbo.Party p on p.PartyId = s.PartyId
+    where p.Name like '%Cato%' and s.Enabled = 1
+    """
+
+    with pyodbc.connect(connection_string) as connection:
+        cursor = connection.cursor()
+        cursor.execute(query)
+        return [row[0] for row in cursor.fetchall() if row[0]]
+
+
+def extract_units_from_subscription_xml(xml_text: str) -> list[str]:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return []
+
+    units: list[str] = []
+    for node in root.iter("Condition"):
+        if node.attrib.get("locator") != "LST_KST":
+            continue
+
+        raw_value = node.attrib.get("value", "")
+        parts = [part.strip() for part in raw_value.split(",")]
+        units.extend(part for part in parts if part)
+
+    return units
+
+
+def get_einrichtung(unit: str) -> str | None:
+    match = re.match(r"^(\d{1,4})", unit)
+    return match.group(1) if match else None
+
+
+def aggregate_units_by_einrichtung(xml_rows: list[str]) -> dict[str, list[str]]:
+    grouped: dict[str, set[str]] = defaultdict(set)
+
+    for xml_text in xml_rows:
+        for unit in extract_units_from_subscription_xml(xml_text):
+            einrichtung = get_einrichtung(unit)
+            if not einrichtung:
+                continue
+            grouped[einrichtung].add(unit)
+
+    return {key: sorted(values) for key, values in sorted(grouped.items())}
+
+
+def write_ndjson(grouped_units: dict[str, list[str]], output_dir: str) -> Path:
+    now = datetime.now(timezone.utc)
+    timestamp = now.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    output_file = Path(output_dir) / f"{now.strftime('%Y%m%dT%H%M%SZ')}.json"
+
+    lines = []
+    for einrichtung, oes in grouped_units.items():
+        payload = {
+            "@timestamp": timestamp,
+            "einrichtung": einrichtung,
+            "oes": oes,
+        }
+        lines.append(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    output_file.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return output_file
+
+
+def main() -> int:
+    args = parse_args()
+    xml_rows = fetch_subscription_xmls(args.server, args.database, args.username, args.password)
+    grouped_units = aggregate_units_by_einrichtung(xml_rows)
+    output_file = write_ndjson(grouped_units, args.output_dir)
+    print(f"Wrote {len(grouped_units)} records to {output_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a dedicated extractor that reads active Cato subscriptions from the configuration database and produces NDJSON suitable for Elasticsearch ingestion.  
- Allow an explicit exception to the PowerShell-first repository policy for cases where Python is preferred, while keeping PowerShell as the default.  
- Ensure downstream processes receive unit lists grouped by `einrichtung` (leading up-to-4 digits) in a stable, timestamped output format.

### Description
- Add `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` which connects to `OrchEsbWskConfiguration` via ODBC (ODBC Driver 18) using SQL auth with `Encrypt=yes;TrustServerCertificate=yes;`, queries active Cato subscriptions, parses XML for `Condition` nodes with `locator="LST_KST"`, splits comma-separated values, deduplicates, groups by `einrichtung`, and writes newline-delimited JSON objects to a datetime-named `.json` file.  
- Update `AGENTS.md` to state that PowerShell is the default and that explicit Python exceptions must use a `Python-` prefix for folder and file names.  
- Update `README.md` to reflect the default-language policy and to document the new `Python-ExtractCatoUnitsForElastic.py` script in the scripts list.

### Testing
- Ran Python syntax check with `python3 -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`, which succeeded.  
- Performed a smoke test by importing the module and running `aggregate_units_by_einrichtung` on sample XML which produced the expected grouped mapping.  
- Verified repository PowerShell examples still load with `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"`, which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a57c277d3c833394d2eca6b420b4f3)