### PR TITLE
Require Python 3.9.25+ for Cato extraction script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
-- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, and writes newline-delimited JSON objects for Elasticsearch pickup (compatible with Python 2.7 and 3.x).
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, and writes newline-delimited JSON objects for Elasticsearch pickup (requires Python 3.9.25+).
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -205,4 +205,4 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Cato unit extraction notes
 
-`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script is kept compatible with both Python 2.7 and Python 3.x runtimes.
+`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script now targets Python 3.9.25 (or newer) runtimes.

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -1,14 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Python-ExtractCatoUnitsForElastic
 
 Connects to OrchEsbWskConfiguration, reads active Cato subscriptions,
 extracts all Condition values for locator="LST_KST", aggregates unit codes by
 Einrichtung (first up-to-4 leading digits), and writes newline-delimited JSON
 objects (not a JSON array) to an output file in the current working directory.
-Compatible with Python 2.7 and Python 3.x.
+Requires Python 3.9.25 or newer.
 """
 
-from __future__ import print_function
 
 import argparse
 import json


### PR DESCRIPTION
### Motivation
- The Cato unit extraction script should target a modern Python runtime and remove legacy Python 2 compatibility hints.
- Repository documentation should reflect the actual supported runtime to avoid confusion when running the script.

### Description
- Updated the script shebang to `#!/usr/bin/env python3` and removed the Python 2 compatibility note in `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`.
- Revised the script header to state "Requires Python 3.9.25 or newer." and removed the unused `from __future__ import print_function` line.
- Updated descriptive references in `README.md` and `ScenarioInfo.md` to indicate the script requires Python `3.9.25+`.

### Testing
- Ran the PowerShell smoke check `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which returned `ok`.
- Ran `python3 --version && python3 -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` which succeeded under the available `python3` interpreter.
- Attempted `python3.9 --version && python3.9 -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` which failed because the `python3.9` binary was not present in the container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5886ff9608333bcb2a1042ccc5193)