### PR TITLE
Improve Python Cato extractor dependency error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
-- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, and writes newline-delimited JSON objects for Elasticsearch pickup (requires Python 3.9.25+).
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, writes newline-delimited JSON objects for Elasticsearch pickup, and reports missing `pyodbc`/unixODBC dependencies with actionable guidance (requires Python 3.9.25+).
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -205,4 +205,4 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Cato unit extraction notes
 
-`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script now targets Python 3.9.25 (or newer) runtimes.
+`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script now targets Python 3.9.25 (or newer) runtimes and fails with clear dependency guidance when `pyodbc` or unixODBC runtime libraries are unavailable.

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from datetime import datetime
 import io
 import os
+import sys
 import xml.etree.ElementTree as ET
 
 
@@ -35,7 +36,19 @@ def parse_args():
 
 
 def fetch_subscription_xmls(server, database, username, password):
-    import pyodbc
+    try:
+        import pyodbc
+    except ImportError as exc:
+        message = str(exc)
+        if "libodbc.so.2" in message:
+            raise RuntimeError(
+                "pyodbc is installed, but the unixODBC runtime library is missing (libodbc.so.2). "
+                "Install unixODBC on the host, for example: 'dnf install unixODBC' or 'apt-get install unixodbc', "
+                "then rerun the script."
+            ) from exc
+        raise RuntimeError(
+            "The 'pyodbc' module is not available. Install it with 'pip install pyodbc' and rerun the script."
+        ) from exc
 
     connection_string = (
         "Driver={ODBC Driver 18 for SQL Server};"
@@ -126,7 +139,12 @@ def write_ndjson(grouped_units, output_dir):
 
 def main():
     args = parse_args()
-    xml_rows = fetch_subscription_xmls(args.server, args.database, args.username, args.password)
+    try:
+        xml_rows = fetch_subscription_xmls(args.server, args.database, args.username, args.password)
+    except RuntimeError as exc:
+        print("Error: {0}".format(exc), file=sys.stderr)
+        return 1
+
     grouped_units = aggregate_units_by_einrichtung(xml_rows)
     output_file = write_ndjson(grouped_units, args.output_dir)
     print("Wrote {0} records to {1}".format(len(grouped_units), output_file))


### PR DESCRIPTION
### Motivation
- Make `Python-ExtractCatoUnitsForElastic.py` fail with a clear, actionable message when the `pyodbc` module or the unixODBC runtime (`libodbc.so.2`) is missing. 
- Prevent an unhelpful traceback for common dependency issues and guide operators toward a fix.

### Description
- Add guarded import of `pyodbc` that converts `ImportError` into a `RuntimeError` with a specific message when `libodbc.so.2` is reported missing and a general message when `pyodbc` is absent. 
- Update `main()` to catch the runtime error, print a concise error to `stderr`, and return a non-zero exit code instead of propagating a traceback. 
- Update `README.md` and `ScenarioInfo.md` to mention the improved dependency guidance for the Cato extractor script. 

### Testing
- Ran Python syntax check with `python3 -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`, which succeeded. 
- Verified the script `--help` output with `python3 Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py --help`, which succeeded. 
- Verified the script is discoverable from PowerShell with `pwsh -NoProfile -Command "Get-Command ./Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py | Out-Null; 'ok'"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a58a2d5b9c8333adb0394199713940)