### PR TITLE
Fix ODBC driver formatting in Python-ExtractCatoUnitsForElastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
-- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, writes newline-delimited JSON objects for Elasticsearch pickup, and reports missing `pyodbc`/unixODBC dependencies with actionable guidance (requires Python 3.9.25+).
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, writes newline-delimited JSON objects for Elasticsearch pickup, and reports dependency or ODBC connection-string issues with actionable guidance.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -205,4 +205,4 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Cato unit extraction notes
 
-`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script now targets Python 3.9.25 (or newer) runtimes and fails with clear dependency guidance when `pyodbc` or unixODBC runtime libraries are unavailable.
+`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script now targets Python 3.9.25 (or newer) runtimes, fails with clear dependency guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and correctly escapes the ODBC driver name in its SQL connection string.

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -51,7 +51,7 @@ def fetch_subscription_xmls(server, database, username, password):
         ) from exc
 
     connection_string = (
-        "Driver={ODBC Driver 18 for SQL Server};"
+        "Driver={{ODBC Driver 18 for SQL Server}};"
         "Server={0};"
         "Database={1};"
         "Uid={2};"


### PR DESCRIPTION
### Motivation
- Avoid a `KeyError` raised by Python's `str.format()` when the ODBC driver name containing braces was interpreted as a format key and keep the repository documentation consistent with the runtime behavior.

### Description
- Escape the ODBC driver braces in the SQL connection string in `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` so the driver name is treated literally (`"Driver={{ODBC Driver 18 for SQL Server}};"`).
- Update `README.md` and `ScenarioInfo.md` to reflect the fix and broaden the script documentation to mention dependency or connection-string guidance.

### Testing
- Successfully ran `python3 -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` (no syntax errors).
- Successfully ran `python3 Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py --help` which produced the expected usage output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5958f20c48333b872aa8a55d5d594)