### PR TITLE
Handle SQL ODBC driver fallback in Cato extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
-- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, writes newline-delimited JSON objects for Elasticsearch pickup, and reports dependency or ODBC connection-string issues with actionable guidance.
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, writes newline-delimited JSON for Elasticsearch pickup, and validates pyodbc/ODBC driver availability (Driver 18 preferred, Driver 17 fallback).
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -205,4 +205,4 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Cato unit extraction notes
 
-`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script now targets Python 3.9.25 (or newer) runtimes, fails with clear dependency guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and correctly escapes the ODBC driver name in its SQL connection string.
+`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script targets Python 3.9.25 (or newer), fails with clear guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and validates SQL Server ODBC drivers before connecting (prefers Driver 18, falls back to Driver 17).

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -50,15 +50,39 @@ def fetch_subscription_xmls(server, database, username, password):
             "The 'pyodbc' module is not available. Install it with 'pip install pyodbc' and rerun the script."
         ) from exc
 
+    available_drivers = set(pyodbc.drivers())
+    preferred_drivers = ["ODBC Driver 18 for SQL Server", "ODBC Driver 17 for SQL Server"]
+    selected_driver = None
+    for candidate in preferred_drivers:
+        if candidate in available_drivers:
+            selected_driver = candidate
+            break
+
+    if not selected_driver:
+        ordered = sorted(available_drivers)
+        message = "No supported SQL Server ODBC driver found."
+        if ordered:
+            raise RuntimeError(
+                "{0} Installed drivers: {1}. Install 'ODBC Driver 18 for SQL Server' or 'ODBC Driver 17 for SQL Server'.".format(
+                    message,
+                    ", ".join(ordered),
+                )
+            )
+        raise RuntimeError(
+            "{0} No ODBC drivers are currently registered. Install unixODBC and a SQL Server ODBC driver (18 or 17).".format(
+                message
+            )
+        )
+
     connection_string = (
-        "Driver={{ODBC Driver 18 for SQL Server}};"
-        "Server={0};"
-        "Database={1};"
-        "Uid={2};"
-        "Pwd={3};"
+        "Driver={{{0}}};"
+        "Server={1};"
+        "Database={2};"
+        "Uid={3};"
+        "Pwd={4};"
         "Encrypt=yes;"
         "TrustServerCertificate=yes;"
-    ).format(server, database, username, password)
+    ).format(selected_driver, server, database, username, password)
 
     query = """
     select SubscriptionXml
@@ -67,7 +91,15 @@ def fetch_subscription_xmls(server, database, username, password):
     where p.Name like '%Cato%' and s.Enabled = 1
     """
 
-    connection = pyodbc.connect(connection_string)
+    try:
+        connection = pyodbc.connect(connection_string)
+    except pyodbc.Error as exc:
+        raise RuntimeError(
+            "Unable to connect with ODBC driver '{0}'. Verify driver installation and SQL connectivity. pyodbc error: {1}".format(
+                selected_driver,
+                exc,
+            )
+        ) from exc
     try:
         cursor = connection.cursor()
         cursor.execute(query)


### PR DESCRIPTION
### Motivation
- Make `Python-ExtractCatoUnitsForElastic.py` robust on hosts with missing or differently-named SQL Server ODBC drivers by detecting available drivers and providing actionable guidance. 
- Avoid hard-failing with an opaque `pyodbc` connection error and give a clear fallback path (Driver 18 → Driver 17) or an explicit install hint when no drivers are available.

### Description
- Added runtime detection of registered ODBC drivers via `pyodbc.drivers()` and select `ODBC Driver 18 for SQL Server` when available, falling back to `ODBC Driver 17 for SQL Server` if not. (File: `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`)
- Emit explicit `RuntimeError` messages that list installed drivers or instruct to install `unixODBC` and a SQL Server ODBC driver when none are registered. (File: `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`)
- Wrap `pyodbc.connect` in a `try/except` and raise a user-facing `RuntimeError` that includes the selected driver and the original `pyodbc` error for easier troubleshooting. (File: `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`)
- Update documentation references to reflect the new driver validation and fallback behavior in `README.md` and `ScenarioInfo.md`.

### Testing
- Ran `python3 -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` which completed successfully. 
- Verified CLI help with `python3 Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py --help` which printed usage information successfully. 
- Imported the module and exercised `aggregate_units_by_einrichtung` with sample XML to validate parsing logic, which returned the expected grouped output. 
- No runtime database connection tests were performed since they depend on host ODBC driver installation and SQL Server connectivity; connection failures are now surfaced with the improved error messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a596ad3cec8333973f403437fc1353)