### PR TITLE
Add fixed `typ` field to Cato unit NDJSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
-- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, writes newline-delimited JSON for Elasticsearch pickup, and validates pyodbc/ODBC driver availability (Driver 18 preferred, Driver 17 fallback).
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, and writes newline-delimited JSON for Elasticsearch pickup with `typ` set to `ADT`.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -205,4 +205,4 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Cato unit extraction notes
 
-`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion. The script targets Python 3.9.25 (or newer), fails with clear guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and validates SQL Server ODBC drivers before connecting (prefers Driver 18, falls back to Driver 17).
+`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion with `typ` fixed to `ADT`. The script targets Python 3.9.25 (or newer), fails with clear guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and validates SQL Server ODBC drivers before connecting (prefers Driver 18, falls back to Driver 17).

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -159,6 +159,7 @@ def write_ndjson(grouped_units, output_dir):
         payload = {
             "@timestamp": timestamp,
             "einrichtung": einrichtung,
+            "typ": "ADT",
             "oes": oes,
         }
         lines.append(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))


### PR DESCRIPTION
### Motivation
- Ensure every NDJSON record emitted by the Cato unit extractor carries a fixed type marker for downstream indexing and filtering.
- Keep repository documentation in sync with the script's output contract.

### Description
- Add a constant `"typ": "ADT"` property to each payload produced by `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` so every NDJSON line includes the type field.
- Update `README.md` to document that `Python-ExtractCatoUnitsForElastic.py` writes NDJSON with `typ` set to `ADT`.
- Update `ScenarioInfo.md` Cato extraction notes to reflect that the NDJSON output contains `typ` fixed to `ADT`.

### Testing
- Successfully compiled the script with `python -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py`.
- Verified the script prints its usage with `python Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py --help` and exited normally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6d7f5e0c8833384a9297af75121b5)