### PR TITLE
Export Cato units as per‑OE NDJSON and add installer for cron/logrotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 - **Create-ProcessModelOverview.ps1** - Parses ProcessModell_* XML files and creates Markdown overviews for model metadata, variables, business keys, merged element detail rows (`Name`, `Type`, `Usage`, `Input Expression`, `Output Expression`), and gateway outgoing edge conditions (including EdgeSequence-based paths and else branches), writing reports to the script-local `Output` folder by default.
 - **Write-ElasticDataToDatabase.ps1** - Reads SUBFL Elasticsearch records for a date range and writes selected MSGID/process/business-key fields (including change type) into SQL Server. Includes SQL templates for table creation and missing-output checks by MSGID/subid.
 - **Resend-FromElastic.ps1** - Queries SUBFL records from Elasticsearch, keeps only the oldest hit per BusinessCaseId/MSGID, and supports grouped reporting, controlled resend/test replay, or curl command export for configured HTTP targets.
-- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, groups units by Einrichtung, and writes newline-delimited JSON for Elasticsearch pickup with `typ` set to `ADT`.
+- **Python-ExtractCatoUnitsForElastic.py** - Reads active Cato subscriptions from SQL Server, extracts `LST_KST` units from subscription XML, and writes one NDJSON row per `oe` (including derived `einrichtung`) for Elasticsearch pickup with `typ` set to `ADT`.
+- **install.sh** (in `Scripts/Python-ExtractCatoUnitsForElastic`) - Installs root crontab execution at `06:34` daily for the Cato export script and configures log rotation for `/var/log/cato_betr`.
 
 ## Shared utilities
 

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -205,4 +205,4 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Cato unit extraction notes
 
-`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, groups unit codes by leading Einrichtung digits, and writes NDJSON output for Elasticsearch ingestion with `typ` fixed to `ADT`. The script targets Python 3.9.25 (or newer), fails with clear guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and validates SQL Server ODBC drivers before connecting (prefers Driver 18, falls back to Driver 17).
+`Python-ExtractCatoUnitsForElastic` reads active Cato subscription XML payloads from `OrchEsbWskConfiguration`, extracts `Condition` entries where `locator="LST_KST"`, and writes NDJSON output with one row per `oe` plus derived `einrichtung` for Elasticsearch ingestion with `typ` fixed to `ADT`. The script targets Python 3.9.25 (or newer), fails with clear guidance when `pyodbc` or unixODBC runtime libraries are unavailable, and validates SQL Server ODBC drivers before connecting (prefers Driver 18, falls back to Driver 17).

--- a/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py
@@ -2,9 +2,9 @@
 """Python-ExtractCatoUnitsForElastic
 
 Connects to OrchEsbWskConfiguration, reads active Cato subscriptions,
-extracts all Condition values for locator="LST_KST", aggregates unit codes by
-Einrichtung (first up-to-4 leading digits), and writes newline-delimited JSON
-objects (not a JSON array) to an output file in the current working directory.
+extracts all Condition values for locator="LST_KST", and writes one NDJSON row
+per OE (no grouped OE arrays) to an output file in the current working
+directory.
 Requires Python 3.9.25 or newer.
 """
 
@@ -12,7 +12,6 @@ Requires Python 3.9.25 or newer.
 import argparse
 import json
 import re
-from collections import defaultdict
 from datetime import datetime
 import io
 import os
@@ -24,7 +23,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description=(
             "Extract LST_KST unit values from active Cato subscriptions and "
-            "write NDJSON grouped by Einrichtung."
+            "write one NDJSON row per OE."
         )
     )
     parser.add_argument("--server", default="orchestrasql.wienkav.at", help="SQL Server host name.")
@@ -133,34 +132,32 @@ def get_einrichtung(unit):
     return match.group(1)
 
 
-def aggregate_units_by_einrichtung(xml_rows):
-    grouped = defaultdict(set)
+def collect_units(xml_rows):
+    unique_units = set()
 
     for xml_text in xml_rows:
         for unit in extract_units_from_subscription_xml(xml_text):
-            einrichtung = get_einrichtung(unit)
-            if not einrichtung:
-                continue
-            grouped[einrichtung].add(unit)
+            if get_einrichtung(unit):
+                unique_units.add(unit)
 
-    output = {}
-    for key in sorted(grouped.keys()):
-        output[key] = sorted(grouped[key])
-    return output
+    return sorted(unique_units)
 
 
-def write_ndjson(grouped_units, output_dir):
+def write_ndjson(units, output_dir):
     now = datetime.utcnow()
     timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     output_file = os.path.join(output_dir, now.strftime("%Y%m%dT%H%M%SZ") + ".json")
 
     lines = []
-    for einrichtung, oes in grouped_units.items():
+    for oe in units:
+        einrichtung = get_einrichtung(oe)
+        if not einrichtung:
+            continue
         payload = {
             "@timestamp": timestamp,
             "einrichtung": einrichtung,
             "typ": "ADT",
-            "oes": oes,
+            "oe": oe,
         }
         lines.append(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
 
@@ -178,9 +175,9 @@ def main():
         print("Error: {0}".format(exc), file=sys.stderr)
         return 1
 
-    grouped_units = aggregate_units_by_einrichtung(xml_rows)
-    output_file = write_ndjson(grouped_units, args.output_dir)
-    print("Wrote {0} records to {1}".format(len(grouped_units), output_file))
+    units = collect_units(xml_rows)
+    output_file = write_ndjson(units, args.output_dir)
+    print("Wrote {0} records to {1}".format(len(units), output_file))
     return 0
 
 

--- a/Scripts/Python-ExtractCatoUnitsForElastic/install.sh
+++ b/Scripts/Python-ExtractCatoUnitsForElastic/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs a root-crontab job for daily Cato unit export and configures log rotation.
+# Script location: /root/work/scripts/shell/cato-betriebsstellen
+
+SCRIPT_DIR="/root/work/scripts/shell/cato-betriebsstellen"
+SCRIPT_FILE="${SCRIPT_DIR}/Python-ExtractCatoUnitsForElastic.py"
+LOGROTATE_CONF="/etc/logrotate.d/cato_betr"
+TARGET_LOG_DIR="/var/log/cato_betr"
+CRON_MARKER="# cato_betr daily export"
+CRON_SCHEDULE="34 6 * * *"
+CRON_CMD="${CRON_SCHEDULE} ${SCRIPT_FILE} >> ${TARGET_LOG_DIR}/cato_export.log 2>&1"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Please run as root." >&2
+  exit 1
+fi
+
+mkdir -p "${TARGET_LOG_DIR}"
+
+touch "${TARGET_LOG_DIR}/cato_export.log"
+chmod 0755 "${TARGET_LOG_DIR}"
+chmod 0644 "${TARGET_LOG_DIR}/cato_export.log"
+
+cat > "${LOGROTATE_CONF}" <<ROTATE
+${TARGET_LOG_DIR}/*.log {
+    daily
+    rotate 14
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+}
+ROTATE
+
+current_cron="$(crontab -l 2>/dev/null || true)"
+filtered_cron="$(printf '%s\n' "${current_cron}" | sed '/cato_betr daily export/d' | sed '/Python-ExtractCatoUnitsForElastic.py/d')"
+
+new_cron="${filtered_cron}"
+if [[ -n "${new_cron}" ]]; then
+  new_cron+=$'\n'
+fi
+new_cron+="${CRON_MARKER}"
+new_cron+=$'\n'
+new_cron+="${CRON_CMD}"
+new_cron+=$'\n'
+
+printf '%s' "${new_cron}" | crontab -
+
+echo "Installed root crontab entry: ${CRON_CMD}"
+echo "Installed logrotate config: ${LOGROTATE_CONF}"


### PR DESCRIPTION
### Motivation
- Simplify the NDJSON output shape so each OE is emitted as a separate JSON line instead of grouping units into `oes` arrays by `einrichtung`.
- Provide an easy installer to schedule the export daily and handle log rotation for operational use.

### Description
- Changed `Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` to collect unique unit codes with `collect_units()` and emit one NDJSON object per `oe` (field `"oe"`) while still including derived `einrichtung` and `typ` in the payload. 
- Replaced the grouped map logic with a flat `sorted` list of units and removed the `oes` array output in favor of a scalar `oe` field. 
- Added `Scripts/Python-ExtractCatoUnitsForElastic/install.sh` which configures a root crontab entry to run the export daily at `06:34`, writes logs to `/var/log/cato_betr/cato_export.log`, and installs a `logrotate` config at `/etc/logrotate.d/cato_betr` with rotation/compression and `copytruncate` behavior. 
- Updated `README.md` and `ScenarioInfo.md` to document the new per‑`oe` NDJSON format and the installer script. 

### Testing
- Executed a PowerShell sanity check with `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which returned `ok` (success). 
- Verified Python syntax with `python -m py_compile Scripts/Python-ExtractCatoUnitsForElastic/Python-ExtractCatoUnitsForElastic.py` which completed without errors. 
- Performed a shell syntax check with `bash -n Scripts/Python-ExtractCatoUnitsForElastic/install.sh` which returned no syntax errors. 
- Ran an inline Python functional check that invoked `collect_units()`/`write_ndjson()` on sample XML and asserted the NDJSON contains one line per `oe`, no `oes` arrays, and parseable JSON, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6e97fafc48333a2947c454f218b36)