### PR TITLE
Move Resend key controls hint into active progress bar

### DIFF
--- a/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
+++ b/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
@@ -216,7 +216,7 @@ if (-not (Test-Path -Path $sharedHelpersPath)) {
 }
 . $sharedHelpersPath
 
-Write-Host 'Key controls during processing: P=pause, R=resume/skip wait, S=single-step, X=stop.' -ForegroundColor Yellow
+$processingControlHint = 'Controls: P=pause, R=resume/skip wait, S=single-step, X=stop'
 
 $script:LogFilePath = $null
 $script:CurlOutputFilePath = $null
@@ -755,7 +755,7 @@ for ($i = 0; $i -lt $records.Count; $i++) {
     $indexDisplay = $i + 1
 
     $progressPercent = if ($records.Count -gt 0) { [int](($indexDisplay * 100) / $records.Count) } else { 0 }
-    Write-Progress -Id 2 -Activity 'Resend processing' -Status "Record $indexDisplay/$($records.Count)" -PercentComplete $progressPercent
+    Write-Progress -Id 2 -Activity 'Resend processing' -Status "Record $indexDisplay/$($records.Count) | $processingControlHint" -PercentComplete $progressPercent
 
     while ($true) {
         $control = Get-ControlAction


### PR DESCRIPTION
### Motivation
- The keyboard controls hint was printed unconditionally before processing, but it is only useful while records are being processed, so it should be shown in the active progress display.

### Description
- Removed the standalone `Write-Host` line that emitted the key controls hint.
- Added a reusable `$processingControlHint` string to hold the controls text.
- Updated the resend loop `Write-Progress` `-Status` to include `$processingControlHint` so the controls appear only while processing.
- Modified file `Scripts/Resend-FromElastic/Resend-FromElastic.ps1` to implement the change.

### Testing
- Performed a PowerShell script load/syntax check with `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which returned `ok` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a936313b2c83338fa0d76890a554fc)