### PR TITLE
Fix HL7 response byte accumulation for AddRange

### DIFF
--- a/Scripts/Send-HL7Message/Send-HL7Message.ps1
+++ b/Scripts/Send-HL7Message/Send-HL7Message.ps1
@@ -283,7 +283,8 @@ try {
         }
 
         if ($bytesRead -gt 0) {
-            $responseBytes.AddRange($buffer[0..($bytesRead - 1)])
+            [byte[]]$chunk = $buffer[0..($bytesRead - 1)]
+            $responseBytes.AddRange($chunk)
             if ($responseBytes.Contains($EB)) {
                 $foundEndByte = $true
             }


### PR DESCRIPTION
### Motivation
- Prevent a runtime conversion error where slicing the byte buffer produced a `System.Object[]` which caused `List[byte].AddRange` to fail when accumulating the HL7 response bytes.

### Description
- Replace the direct slice passed to `AddRange` with an explicit cast: create `[byte[]]$chunk = $buffer[0..($bytesRead - 1)]` and call `$responseBytes.AddRange($chunk)` in `Scripts/Send-HL7Message/Send-HL7Message.ps1`.

### Testing
- Ran PowerShell basic script validation with `pwsh -NoProfile -Command "Get-Command ./Scripts/Send-HL7Message/Send-HL7Message.ps1 | Out-Null; 'ok'"` which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dccbbb181483338ef685873321997a)