### PR TITLE
Adjust Get-PatientInfo default date range to last 14 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ All scripts are located under the `Scripts` folder, each in its own subfolder na
 
 ## Shared date-range behavior
 
-Scripts that expose `StartDate`/`EndDate` now also support `Timespan` as an alternative to `EndDate`. `Timespan` accepts either a number (minutes) or a PowerShell `TimeSpan` value. When `EndDate` and `Timespan` are both omitted, a default window of 15 minutes is used from `StartDate`.
+Scripts that expose `StartDate`/`EndDate` can support `Timespan` as an alternative to `EndDate`. `Timespan` accepts either a number (minutes) or a PowerShell `TimeSpan` value. `Get-PatientInfo` defaults to the last 14 days ending at the current time when `StartDate`, `EndDate`, and `Timespan` are all omitted.

--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -201,7 +201,7 @@ When the current commit is not directly tagged, the status column shows the most
 ## Script parameter conventions
 - Repository scripts that expose both `StartDate` and `EndDate` can also accept `Timespan` as an alternative end-bound.
 - `Timespan` accepts numeric minute values and PowerShell `TimeSpan` values.
-- If neither `EndDate` nor `Timespan` is supplied, a default 15-minute window is used from `StartDate`.
+- `Get-PatientInfo` defaults to the last 14 days ending at the current time when `StartDate`, `EndDate`, and `Timespan` are omitted.
 
 ## Orchestra log analysis notes
 

--- a/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
+++ b/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
@@ -25,8 +25,8 @@
 
 .PARAMETER StartDate
     Optional inclusive start date for the time range filter applied to the specified
-    `ElasticTimeField`. If omitted and EndDate is also omitted, the script derives
-    StartDate from Timespan (or 15 minutes by default) as EndDate minus Timespan.
+    `ElasticTimeField`. If omitted and EndDate is also omitted, the script defaults
+    to the last 14 days ending at the current time.
 
 .PARAMETER EndDate
     Optional inclusive end date for the time range filter applied to the specified
@@ -172,7 +172,7 @@ if ($includeEndDate -and $PSBoundParameters.ContainsKey('Timespan')) {
     throw 'Specify either EndDate or Timespan, not both.'
 }
 
-if (-not $includeEndDate) {
+if ($PSBoundParameters.ContainsKey('Timespan')) {
     $effectiveTimespan = Resolve-EffectiveTimespan -Value $Timespan
     if ($StartDate) {
         $EndDate = $StartDate.Add($effectiveTimespan)
@@ -180,7 +180,14 @@ if (-not $includeEndDate) {
         $EndDate = Get-Date
         $StartDate = $EndDate.Subtract($effectiveTimespan)
     }
-    $includeEndDate = $true
+} else {
+    if (-not $EndDate) {
+        $EndDate = Get-Date
+    }
+
+    if (-not $StartDate) {
+        $StartDate = $EndDate.AddDays(-14)
+    }
 }
 
 if (-not $PIDISH -and -not $CASENO) {

--- a/SubflElasticInfo.md
+++ b/SubflElasticInfo.md
@@ -43,7 +43,7 @@ The different CASENO values (`BK._CASENO`, `BK._CASENO_BC`, and `BK._CASENO_ISH`
 ## Date-range parameters in SUBFL scripts
 - SUBFL scripts in this repository that expose `StartDate`/`EndDate` also accept `Timespan` as an alternative to `EndDate`.
 - `Timespan` supports either a numeric minute value or a PowerShell `TimeSpan` input.
-- If neither `EndDate` nor `Timespan` is provided, the scripts apply a default range of 15 minutes from `StartDate`.
+- `Get-PatientInfo` defaults to the last 14 days ending at the current time when `StartDate`, `EndDate`, and `Timespan` are omitted.
 
 ## SQL export field set
 


### PR DESCRIPTION
### Motivation
- Make `Get-PatientInfo` return a more useful default window for interactive troubleshooting by using the last 14 days when no date-range parameters are supplied.
- Preserve existing `Timespan` semantics so callers who explicitly provide a `Timespan` continue to get the derived window behavior.
- Keep repository documentation in sync with the new `Get-PatientInfo` default to avoid surprise for operators.

### Description
- Change parameter handling in `Scripts/Get-PatientInfo/Get-PatientInfo.ps1` so that when `StartDate`, `EndDate`, and `Timespan` are all omitted the script sets `EndDate = Get-Date` and `StartDate = $EndDate.AddDays(-14)` and otherwise preserves the `Timespan` branch that derives `EndDate` from `StartDate`.
- Update the comment-based help in `Get-PatientInfo.ps1` to document the new 14-day default window.
- Update repository documentation in `README.md`, `ScenarioInfo.md`, and `SubflElasticInfo.md` to mention that `Get-PatientInfo` defaults to the last 14 days when no date parameters are provided.

### Testing
- Ran the basic PowerShell validation `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-PatientInfo/Get-PatientInfo.ps1 | Out-Null; 'ok'"` which returned `ok` indicating the script loads without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f074aeac4c83339f724c487808b948)