### PR TITLE
Fix clipboard HTML format handling in Get-PatientInfo

### DIFF
--- a/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
+++ b/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
@@ -331,9 +331,9 @@ function Publish-PatientClipboard {
     try {
         Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
         $dataObject = [System.Windows.Forms.DataObject]::new()
-        $dataObject.SetData([System.Windows.Forms.TextDataFormat]::Text, $plainText)
-        $dataObject.SetData([System.Windows.Forms.TextDataFormat]::UnicodeText, $plainText)
-        $dataObject.SetData([System.Windows.Forms.TextDataFormat]::Html, $htmlFragment)
+        $dataObject.SetData([System.Windows.Forms.DataFormats]::Text, $plainText)
+        $dataObject.SetData([System.Windows.Forms.DataFormats]::UnicodeText, $plainText)
+        $dataObject.SetData([System.Windows.Forms.DataFormats]::Html, $htmlFragment)
         [System.Windows.Forms.Clipboard]::SetDataObject($dataObject, $true)
     } catch {
         Set-Clipboard -Value $plainText


### PR DESCRIPTION
### Motivation
- Fix a runtime error when registering HTML clipboard data in `Publish-PatientClipboard` by using the correct clipboard format identifiers so the script can place both plain text and HTML on the clipboard.

### Description
- Replace `SetData([System.Windows.Forms.TextDataFormat]::...)` calls with `SetData([System.Windows.Forms.DataFormats]::..., ...)` for `Text`, `UnicodeText`, and `Html` in `Scripts/Get-PatientInfo/Get-PatientInfo.ps1` to use the expected data-format names and preserve the existing plain-text fallback behavior.

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-PatientInfo/Get-PatientInfo.ps1 | Out-Null; 'ok'"` and it returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1fc224b58833381de43ca7d5bbc2b)