### PR TITLE
Fail fast on PatAuskunft SOAP request errors

### DIFF
--- a/Scripts/Call-PatAuskunft/Call-PatAuskunft.ps1
+++ b/Scripts/Call-PatAuskunft/Call-PatAuskunft.ps1
@@ -92,6 +92,8 @@ param(
     [switch]$ResetCredentials
 )
 
+$ErrorActionPreference = 'Stop'
+
 
 function Write-ColorizedXml {
     [CmdletBinding()]
@@ -270,7 +272,12 @@ $soapEnvelope = @"
 </soap:Envelope>
 "@
 
-$response = Invoke-WebRequest -Uri $serviceUrl -Method Post -Credential $credential -ContentType 'text/xml; charset=utf-8' -Body $soapEnvelope
+try {
+    $response = Invoke-WebRequest -Uri $serviceUrl -Method Post -Credential $credential -ContentType 'text/xml; charset=utf-8' -Body $soapEnvelope -ErrorAction Stop
+}
+catch {
+    throw "PatAuskunft request failed for environment '$($Environment)': $($_.Exception.Message)"
+}
 
 [xml]$responseXml = $response.Content
 $ns = New-Object System.Xml.XmlNamespaceManager($responseXml.NameTable)


### PR DESCRIPTION
### Motivation
- Prevent the script from continuing after a failed SOAP request which caused cascading null-reference errors when parsing the response.

### Description
- Set `$ErrorActionPreference = 'Stop'` so non-terminating errors are promoted to terminating errors.
- Wrap the `Invoke-WebRequest` call with `-ErrorAction Stop` inside a `try/catch` and throw a single clear error that includes the `Environment` and the underlying exception message.

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Call-PatAuskunft/Call-PatAuskunft.ps1 | Out-Null; 'ok'"` which returned `ok` indicating the script loads without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f894f6e86083339cbea025bacd2363)