### PR TITLE
Add AID alias to Get-PatientInfo CASENO parameter

### DIFF
--- a/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
+++ b/Scripts/Get-PatientInfo/Get-PatientInfo.ps1
@@ -64,7 +64,7 @@
     for the patient are retrieved.
 
 .PARAMETER CASENO
-    Case identifier. The script infers whether it is `BK._CASENO_ISH` (10 digits),
+    Case identifier (alias: AID). The script infers whether it is `BK._CASENO_ISH` (10 digits),
     `BK._CASENO_BC` (9 alphanumeric characters), or `BK._CASENO`
     (two 8-digit numbers separated by whitespace) and uses the matching field for
     searching.
@@ -131,6 +131,7 @@ param(
     [Parameter(Mandatory=$false)]
     [string]$PIDISH,
 
+    [Alias('AID')]
     [Parameter(Mandatory=$false)]
     [string]$CASENO,
 


### PR DESCRIPTION
### Motivation
- Standardize parameter usage so `AID` can be passed as a synonym for `CASENO` and make the script help explicit about the alias.

### Description
- Add `[Alias('AID')]` to the `CASENO` parameter and update the `.PARAMETER CASENO` help text in `Scripts/Get-PatientInfo/Get-PatientInfo.ps1` so `-AID` and `-CASENO` behave equivalently.

### Testing
- Ran `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-PatientInfo/Get-PatientInfo.ps1 | Out-Null; 'ok'"` which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f896f536608333891b4982197a5504)