### PR TITLE
Respect SourceInfo.ProcessState unless `ProcessState` is explicitly provided

### DIFF
--- a/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
+++ b/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
@@ -103,7 +103,8 @@
     When set, clears _MSGID header.
 
 .PARAMETER ProcessState
-    Fallback ProcessState for SourceInfoMsg. Defaults to 'Original'.
+    ProcessState override for SourceInfoMsg when explicitly provided.
+    If omitted, ProcessState from SourceInfo is used when available; otherwise 'Original'.
 
 .PARAMETER OutputDirectory
     Optional output directory for logs.
@@ -481,7 +482,8 @@ function Get-SourceInfoXml {
         [object]$Source,
         [string]$SubscriptionFilterParty,
         [string]$SubscriptionFilterId,
-        [string]$ResolvedProcessState,
+        [string]$FallbackProcessState,
+        [bool]$UseProvidedProcessState = $false,
         [string]$TargetName
     )
 
@@ -521,7 +523,7 @@ function Get-SourceInfoXml {
         ''
     }
 
-    $processStateValue = if ($sourceInfo -and $sourceInfo.SourceInfo.ProcessState) { "$($sourceInfo.SourceInfo.ProcessState)" } else { $ResolvedProcessState }
+    $processStateValue = if ($UseProvidedProcessState) { $FallbackProcessState } elseif ($sourceInfo -and $sourceInfo.SourceInfo.ProcessState) { "$($sourceInfo.SourceInfo.ProcessState)" } else { $FallbackProcessState }
     $instanceValue = if ($TargetName) { $TargetName } elseif ($sourceInfo -and $sourceInfo.SourceInfo.Instance) { "$($sourceInfo.SourceInfo.Instance)" } else { '' }
 
     $doc = New-Object System.Xml.XmlDocument
@@ -1019,7 +1021,7 @@ for ($i = 0; $i -lt $records.Count; $i++) {
     }
 
     $headersOut = @{
-        'SourceInfoMsg' = (Get-SourceInfoXml -Source $current -SubscriptionFilterParty $TargetParty -SubscriptionFilterId $TargetSubId -ResolvedProcessState $ProcessState -TargetName $Target)
+        'SourceInfoMsg' = (Get-SourceInfoXml -Source $current -SubscriptionFilterParty $TargetParty -SubscriptionFilterId $TargetSubId -FallbackProcessState $(if ($PSBoundParameters.ContainsKey('ProcessState')) { $ProcessState } else { 'Original' }) -UseProvidedProcessState $PSBoundParameters.ContainsKey('ProcessState') -TargetName $Target)
         'SUBFL_source_host' = 'ElasticReinject'
         'BuKeysString' = (ConvertTo-BusinessKeysString -Source $current -ReplacementPairs $ReplacementPairs)
         '_MSGID' = $(if ($NewBusinessCaseIds.IsPresent) { '' } else { $msgId })


### PR DESCRIPTION
### Motivation
- Avoid unintentionally overwriting `SourceInfo.ProcessState` when the `ProcessState` script parameter is not explicitly supplied. 
- Clarify parameter semantics so an explicit `ProcessState` acts as an override while omitted parameter preserves embedded `SourceInfo` values or falls back to `Original`.

### Description
- Update parameter documentation for `ProcessState` to describe the new override semantics. 
- Change `Get-SourceInfoXml` signature to accept `FallbackProcessState` and a `UseProvidedProcessState` boolean flag and adjust logic to prefer `SourceInfo.ProcessState` unless `UseProvidedProcessState` is true. 
- Update call site to pass `FallbackProcessState` as either the provided `ProcessState` or `'Original'` and set `UseProvidedProcessState` using `$PSBoundParameters.ContainsKey('ProcessState')`.

### Testing
- Ran `PSScriptAnalyzer` and PowerShell syntax validation against the modified script, and both checks succeeded. 
- Executed automated smoke tests exercising `Get-SourceInfoXml` with and without the `ProcessState` parameter to confirm the code path that preserves embedded `SourceInfo.ProcessState` and the path that forces the explicit override, and both behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb1c8726208333b546040ca3ee4c2c)