### PR TITLE
Add usage examples to Resend-FromElastic help

### DIFF
--- a/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
+++ b/Scripts/Resend-FromElastic/Resend-FromElastic.ps1
@@ -19,6 +19,22 @@
     When multiple records share the same BusinessCaseId/MSGID, only the oldest
     record (lowest @timestamp) is kept for processing.
 
+.EXAMPLE
+    .\Resend-FromElastic.ps1 -Action Query -BusinessCaseId 021000005865627450708147
+    Gets information for a single BusinessCaseId/MSGID. If a result is found, it can be sent later.
+
+.EXAMPLE
+    .\Resend-FromElastic.ps1 -StartDate "2026-05-01 00:00:00" -EndDate "2026-05-21 00:00:00" -ScenarioName *3287 -WorkflowPattern ERROR
+    Searches for errors of a specific scenario in a given time range.
+
+.EXAMPLE
+    .\Resend-FromElastic.ps1 -Action Send -Target prod01-wsk -BusinessCaseId 011000014048434700509727,011000014048382560508756 -TargetSubId 123
+    Sends two specific records to prod01-wsk, but only to subscription 123 (when it is resolved).
+
+.EXAMPLE
+    .\Resend-FromElastic.ps1 -Action Send -Target prod01-wsk -CaseNo "92134461    26080726" -ScenarioName *HCM_empfangen* -ProcessState Test -Mode Curl -OutputDirectory output
+    Creates a text file with curl statements for prod01-wsk. Received HCM messages are replayed with ProcessState set to Test.
+
 .PARAMETER StartDate
     Inclusive start timestamp for Elasticsearch filtering (interpreted as local time unless explicitly marked as UTC). Defaults to now minus 7 days.
 


### PR DESCRIPTION
### Motivation
- Provide concise, practical usage examples for common query and resend scenarios to make the script easier to use without changing runtime behavior.

### Description
- Added four `.EXAMPLE` help blocks to the top of `Scripts/Resend-FromElastic/Resend-FromElastic.ps1` demonstrating query-by-`BusinessCaseId/MSGID`, date-range error search, sending multiple `BusinessCaseId`s with `TargetSubId`, and generating `curl` output; no functional code changes were made.

### Testing
- Ran the PowerShell basic validation `pwsh -NoProfile -Command "Get-Command ./Scripts/Resend-FromElastic/Resend-FromElastic.ps1 | Out-Null; 'ok'"` which returned `ok`, indicating the script is discoverable and the help update did not introduce syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb3761ff888333a2144e27a8d7d8d8)