### PR TITLE
Get-DeploymentInfo: state-derived indicator and version formatting

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -211,6 +211,10 @@ When the current commit is not directly tagged, the status column shows the most
 For grouping stability, the script supports a settings file with `regex;replacement` normalization rules that are applied before aggregation.
 The summary output tracks first/last occurrence, count, severity, flattened statement text, and the first stacktrace line.
 
+## Deployment status overview notes
+
+`Get-DeploymentInfo` derives scenario state indicators from `serviceState` and `persistentSubcription` values and keeps version comparison coloring limited to the displayed version numbers. Version output now keeps fixed-width alignment while replacing numeric leading zeros with spaces.
+
 ## HL7 message send notes
 
 `Send-HL7Message` sends HL7 payloads via MLLP using `-Protocol Tcp`, `-Protocol Tls`, or `-Protocol TlsWithCertificate` with configurable wire encoding. It supports file-based input (`-Path`) and dynamic request creation (`-Message A19` plus `-AID`, optional `-Sender`), prints the outbound request in color, and can continue despite TLS certificate policy errors when `-IgnoreTlsError` is used (warnings are still written). Replies are extracted from MLLP framing and either printed with colorized HL7 separators (`|`, `^`, `~`, `\`, `&`) or saved as UTF-8 via `-ResponsePath`; if no response arrives, the script now emits an explicit error with protocol guidance.

--- a/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
+++ b/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
@@ -97,6 +97,18 @@ function Get-ParsedVersionNumber {
     return -1
 }
 
+function Get-VersionDisplayText {
+    param([string]$GitVersion)
+
+    if ([string]::IsNullOrWhiteSpace($GitVersion)) { return '' }
+    $display = $GitVersion
+    if ($display -match '^[gG](.+)$') { $display = $Matches[1] }
+    if ($display -match '^0+(?=\d)') {
+        $display = [regex]::Replace($display, '^0+(?=\d)', { param($m) ' ' * $m.Length })
+    }
+    return $display
+}
+
 function Get-StateColorName {
     param([int]$PersistentSubscription,[int]$ServiceState)
     if ($PersistentSubscription -ne 1 -and $ServiceState -eq 1) { return 'DarkGray' }
@@ -146,8 +158,7 @@ $lines = New-Object System.Collections.Generic.List[string]
 if ($Server.Count -eq 1) {
     $single = $allServerData[$Server[0]] | Sort-Object Name
     foreach ($item in $single) {
-        $versionShort = $item.Parsed.GitVersion
-        if ($versionShort -match '^[gG](.+)$') { $versionShort = $Matches[1] }
+        $versionShort = Get-VersionDisplayText -GitVersion $item.Parsed.GitVersion
         $line = "{0,-62} {1,-8} {2,-12} {3}" -f $item.Name, $versionShort, $item.UserName, $item.ModifiedAt
         if ($OutputDirectory) {
             $lines.Add($line) | Out-Null
@@ -184,7 +195,7 @@ if ($Server.Count -eq 1) {
                 $entry = $entries[$idx]
                 if (-not $entry) { $parts += "-"; continue }
                 $v = $entry.Parsed.GitVersion
-                if ($v -match '^[gG](.+)$') { $v = $Matches[1] }
+                $v = Get-VersionDisplayText -GitVersion $v
                 $parts += "$($Server[$idx]):$($v)"
             }
             $lines.Add(("{0,-62} {1}" -f $name, ($parts -join ' | '))) | Out-Null
@@ -200,9 +211,10 @@ if ($Server.Count -eq 1) {
                     continue
                 }
                 $v = $entry.Parsed.GitVersion
-                if ($v -match '^[gG](.+)$') { $v = $Matches[1] }
+                $v = Get-VersionDisplayText -GitVersion $v
+                $stateColor = Get-StateColorName -PersistentSubscription $entry.PersistentSubscription -ServiceState $entry.ServiceState
                 $vc = if ($entry.GitNumeric -eq $max) { 'Green' } elseif ($allEqual) { 'White' } else { 'DarkYellow' }
-                Write-Host $indicator.Char -NoNewline -ForegroundColor $vc
+                Write-Host $indicator.Char -NoNewline -ForegroundColor $stateColor
                 Write-Host ' ' -NoNewline
                 Write-Host ("{0,-10}" -f $v) -NoNewline -ForegroundColor $vc
             }


### PR DESCRIPTION
### Motivation
- Ensure the indicator box reflects actual runtime state by deriving its color from `serviceState` and `persistentSubcription` rather than from the version comparison.
- Keep compare-based coloring limited to the version text so the indicator communicates state while version colors communicate relative version differences.
- Preserve fixed-width alignment for version columns by replacing leading numeric zeros with spaces instead of printing the zeros.

### Description
- Added `Get-VersionDisplayText` to strip an optional `g`/`G` prefix and replace leading numeric zeros with spaces for aligned fixed-width version output.
- Replaced inline `g`-stripping calls with `Get-VersionDisplayText` in single-server, multi-server file, and console output paths. 
- Changed the indicator box color to use `Get-StateColorName` (derived from `serviceState` and `persistentSubcription`) while leaving compare-based colors applied only to the version numbers.
- Documented the behavior change in `ScenarioInfo.md` and updated `Get-DeploymentInfo.ps1` accordingly.

### Testing
- Ran a basic PowerShell command check `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1 | Out-Null; 'ok'"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02f955eac88333af95be6dd0f699f0)