### PR TITLE
Get-DeploymentInfo: use `active` flag and include missing deployments in OnlyDifferences

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -213,7 +213,7 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 
 ## Deployment status overview notes
 
-`Get-DeploymentInfo` derives scenario state indicators from `serviceState` and `persistentSubcription` values and keeps version comparison coloring limited to the displayed version numbers. Version output now keeps fixed-width alignment while replacing numeric leading zeros with spaces.
+`Get-DeploymentInfo` derives scenario state indicators from `active` and `persistentSubcription` values (with `serviceState` fallback for older responses) and keeps version comparison coloring limited to the displayed version numbers. `OnlyDifferences` now also keeps rows where a scenario is missing on one or more compared servers. Version output now keeps fixed-width alignment while replacing numeric leading zeros with spaces.
 
 ## HL7 message send notes
 

--- a/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
+++ b/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
@@ -110,10 +110,10 @@ function Get-VersionDisplayText {
 }
 
 function Get-StateColorName {
-    param([int]$PersistentSubscription,[int]$ServiceState)
-    if ($PersistentSubscription -ne 1 -and $ServiceState -eq 1) { return 'DarkGray' }
-    if ($PersistentSubscription -ne 1 -and $ServiceState -ne 1) { return 'DarkYellow' }
-    if ($ServiceState -eq 1) { return 'White' }
+    param([int]$PersistentSubscription,[bool]$Active)
+    if ($PersistentSubscription -ne 1 -and $Active) { return 'DarkGray' }
+    if ($PersistentSubscription -ne 1 -and -not $Active) { return 'DarkYellow' }
+    if ($Active) { return 'White' }
     return 'Yellow'
 }
 
@@ -142,6 +142,7 @@ foreach ($serverName in $Server) {
         [pscustomobject]@{
             Name = $_.name
             ServiceState = [int]$_.serviceState
+            Active = if ($null -ne $_.active) { [bool]$_.active } else { ([int]$_.serviceState -eq 1) }
             PersistentSubscription = [int]$_.persistentSubcription
             UserName = $_.userName
             ModifiedAt = $_.modifiedAt
@@ -163,7 +164,7 @@ if ($Server.Count -eq 1) {
         if ($OutputDirectory) {
             $lines.Add($line) | Out-Null
         } else {
-            $color = Get-StateColorName -PersistentSubscription $item.PersistentSubscription -ServiceState $item.ServiceState
+            $color = Get-StateColorName -PersistentSubscription $item.PersistentSubscription -Active $item.Active
             Write-Host $line -ForegroundColor $color
         }
     }
@@ -187,7 +188,8 @@ if ($Server.Count -eq 1) {
 
         $versions = @($entries | Where-Object { $_ } | ForEach-Object { $_.GitNumeric })
         $allEqual = ($versions.Count -gt 0) -and (($versions | Select-Object -Unique).Count -eq 1)
-        if ($OnlyDifferences -and $allEqual) { continue }
+        $hasMissingDeployment = ($entries | Where-Object { -not $_ }).Count -gt 0
+        if ($OnlyDifferences -and $allEqual -and -not $hasMissingDeployment) { continue }
 
         if ($OutputDirectory) {
             $parts = @()
@@ -212,7 +214,7 @@ if ($Server.Count -eq 1) {
                 }
                 $v = $entry.Parsed.GitVersion
                 $v = Get-VersionDisplayText -GitVersion $v
-                $stateColor = Get-StateColorName -PersistentSubscription $entry.PersistentSubscription -ServiceState $entry.ServiceState
+                $stateColor = Get-StateColorName -PersistentSubscription $entry.PersistentSubscription -Active $entry.Active
                 $vc = if ($entry.GitNumeric -eq $max) { 'Green' } elseif ($allEqual) { 'White' } else { 'DarkYellow' }
                 Write-Host $indicator.Char -NoNewline -ForegroundColor $stateColor
                 Write-Host ' ' -NoNewline


### PR DESCRIPTION
### Motivation
- The Orchestra API exposes an `active` boolean and this should drive state-coloring instead of relying solely on `serviceState -eq 1`, while still supporting older responses.
- `OnlyDifferences` should not hide scenarios that are missing on one or more compared servers even when the present versions are equal.

### Description
- Changed `Get-StateColorName` to accept a `[bool]$Active` parameter and updated its color logic to use `Active` instead of `ServiceState`.
- Each deployment entry now includes an `Active` property set with `Active = if ($null -ne $_.active) { [bool]$_.active } else { ([int]$_.serviceState -eq 1) }` to preserve backward compatibility.
- Wired the new `Active` property into both single-server and multi-server output paths for state coloring and indicators.
- Modified `OnlyDifferences` to compute `$hasMissingDeployment` and to keep rows when a scenario is missing on one or more servers; updated `ScenarioInfo.md` to document the new behavior.

### Testing
- Ran the basic PowerShell sanity check `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1 | Out-Null; 'ok'"` which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02fc48a4b48333b179f378daf62524)