### PR TITLE
Fix Get-DeploymentInfo OnlyDifferences to include missing scenarios

### DIFF
--- a/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
+++ b/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
@@ -181,10 +181,14 @@ if ($Server.Count -eq 1) {
     }
 
     foreach ($name in $scenarioNames) {
-        $entries = foreach ($srv in $Server) {
-            $allServerData[$srv] | Where-Object Name -eq $name | Select-Object -First 1
-        }
-        if (-not ($entries | Where-Object { $_ })) { continue }
+        $entries = @(
+            for ($idx = 0; $idx -lt $Server.Count; $idx++) {
+                $srv = $Server[$idx]
+                $entry = $allServerData[$srv] | Where-Object Name -eq $name | Select-Object -First 1
+                ,$entry
+            }
+        )
+        if (-not ($entries | Where-Object { $null -ne $_ })) { continue }
 
         $versions = @($entries | Where-Object { $_ } | ForEach-Object { $_.GitNumeric })
         $allEqual = ($versions.Count -gt 0) -and (($versions | Select-Object -Unique).Count -eq 1)


### PR DESCRIPTION
### Motivation
- `Get-DeploymentInfo.ps1` was skipping scenario rows in multi-server comparisons when a scenario existed on one server but was missing on another, which caused `-OnlyDifferences` to omit those cases. 
- The intent is to preserve per-server slots (including `null`) so missing deployments are detected and shown as differences.

### Description
- Replaced the previous `foreach ($srv in $Server) { ... }` row construction with an explicit indexed `for` loop that builds an array and injects each slot (including `,$entry`) so `null` entries are preserved. 
- Changed the non-empty row guard to `if (-not ($entries | Where-Object { $null -ne $_ })) { continue }` to explicitly check for non-null entries. 
- No other output formatting or filtering logic was altered so version comparison and `-OnlyDifferences` behavior now correctly includes scenarios missing on one or more servers.

### Testing
- Ran a basic PowerShell load/sanity check with `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1 | Out-Null; 'ok'"` which returned `ok`.
- No other automated tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02fe81bfb88333a9b02d760cfcc137)