### PR TITLE
Fix Get-DeploymentInfo landscape assignment type mismatch

### DIFF
--- a/ScenarioInfo.md
+++ b/ScenarioInfo.md
@@ -214,6 +214,7 @@ The summary output tracks first/last occurrence, count, severity, flattened stat
 ## Deployment status overview notes
 
 `Get-DeploymentInfo` derives scenario state indicators from `active` and `persistentSubcription` values (with `serviceState` fallback for older responses) and keeps version comparison coloring limited to the displayed version numbers. `OnlyDifferences` now also keeps rows where a scenario is missing on one or more compared servers. Version output now keeps fixed-width alignment while replacing numeric leading zeros with spaces.
+Landscape mode now materializes per-server landscape rows as a plain object array before storing them in the server map to avoid type-mismatch assignment errors during landscape comparisons.
 
 ## HL7 message send notes
 

--- a/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
+++ b/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
@@ -183,7 +183,7 @@ function Get-DbVirtualProperties {
     return $result
 }
 
-$allServerData = @{}
+[hashtable]$allServerData = @{}
 foreach ($serverName in $Server) {
     $baseUrl = Get-ServerBaseUrl -ServerName $serverName
     $scenarioInfoUrl = "$($baseUrl)/OrchDyn/deployment/scenarioInfos"
@@ -246,7 +246,7 @@ foreach ($serverName in $Server) {
             }) | Out-Null
         }
     }
-    $allServerData[$serverName] = @($landscapeRows)
+    $allServerData[$serverName] = @($landscapeRows.ToArray())
 }
 
 $scenarioNames = $allServerData.Values | ForEach-Object { $_.Name } | Sort-Object -Unique


### PR DESCRIPTION
### Motivation
- Prevent runtime `Argument types do not match` failures observed when running `Get-DeploymentInfo` in `Landscape` mode caused by assigning a `List[object]` directly into the per-server map.
- Ensure stable, predictable storage type for per-server landscape rows so subsequent comparisons and lookups behave consistently.

### Description
- Explicitly type the server map as a hashtable by declaring `[hashtable]$allServerData = @{}` to make the intent and storage semantics explicit.
- Materialize the collected `System.Collections.Generic.List[object]` into a plain object array when storing it into the server map using `$allServerData[$serverName] = @($landscapeRows.ToArray())` to avoid type-mismatch assignments.
- Update `ScenarioInfo.md` to document that landscape mode now materializes per-server landscape rows as a plain object array before storing them in the server map.

### Testing
- Ran a basic PowerShell load/syntax check with `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1 | Out-Null; 'ok'"`, which returned `ok` and thus succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03174224e883338ffc133f41dba538)