### PR TITLE
Refine landscape output for empty deployment values

### DIFF
--- a/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
+++ b/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
@@ -320,7 +320,7 @@ if ($Mode -eq 'Landscape') {
             }
             $existingValues = @($values | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
             $hasMissingValue = ($values | Where-Object { [string]::IsNullOrWhiteSpace($_) }).Count -gt 0
-            if ($existingValues.Count -eq 0 -and -not $hasMissingValue) { continue }
+            if ($existingValues.Count -eq 0) { continue }
             $allEqual = (($existingValues | Select-Object -Unique).Count -eq 1) -and -not $hasMissingValue
             if ($OnlyDifferences) {
                 if ($valueType -in @('Server','Database')) {
@@ -332,12 +332,12 @@ if ($Mode -eq 'Landscape') {
             $baseLine = "{0,-49} {1,-2} {2,-34} {3,-14}" -f $scenarioLabel,$icon,$entryName,$valueType
             if ($OutputDirectory) {
                 $line = $baseLine
-                foreach ($v in $values) { $line += ("  {0,-52}" -f $(if($v){$v}else{'-'})) }
+                foreach ($v in $values) { $line += ("  {0,-52}" -f $(if($v){$v}else{''})) }
                 $lines.Add($line) | Out-Null
             } else {
                 Write-Host $baseLine -NoNewline
                 foreach ($v in $values) {
-                    $display = if ($v) { $v } else { '-' }
+                    $display = if ($v) { $v } else { '' }
                     $color = if ($allEqual) { 'Green' } else { 'Yellow' }
                     Write-Host ("  {0,-52}" -f $display) -NoNewline -ForegroundColor $color
                 }


### PR DESCRIPTION
### Motivation
- Previous output produced rows filled only with `-` placeholders for value-types where no server had any value, creating noisy output.
- The change aims to omit totally empty value-type rows and stop rendering `-` placeholders so blank cells are shown instead.

### Description
- In `Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1` skip a landscape `Value-Type` row when there are no existing (non-whitespace) values across all compared servers by changing the empty-row condition to `if ($existingValues.Count -eq 0) { continue }`.
- Render missing per-server values as empty strings in the file output instead of `'-'` placeholders by replacing `$(if($v){$v}else{'-'})` with `$(if($v){$v}else{''})`.
- Render missing per-server values as blank cells in console output instead of `'-'` by replacing `if ($v) { $v } else { '-' }` with `if ($v) { $v } else { '' }`, while preserving existing coloring and difference behavior.

### Testing
- Ran the basic PowerShell validation `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1 | Out-Null; 'ok'"` which returned `ok`.
- The change was applied to `Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1` and the script loaded without syntax errors during the check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a032112ab608333881e7f6478f09e1a)