### PR TITLE
Restore '-' placeholder for missing landscape values in Get-DeploymentInfo

### DIFF
--- a/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
+++ b/Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1
@@ -332,12 +332,12 @@ if ($Mode -eq 'Landscape') {
             $baseLine = "{0,-49} {1,-2} {2,-34} {3,-14}" -f $scenarioLabel,$icon,$entryName,$valueType
             if ($OutputDirectory) {
                 $line = $baseLine
-                foreach ($v in $values) { $line += ("  {0,-52}" -f $(if($v){$v}else{''})) }
+                foreach ($v in $values) { $line += ("  {0,-52}" -f $(if($v){$v}else{'-'})) }
                 $lines.Add($line) | Out-Null
             } else {
                 Write-Host $baseLine -NoNewline
                 foreach ($v in $values) {
-                    $display = if ($v) { $v } else { '' }
+                    $display = if ($v) { $v } else { '-' }
                     $color = if ($allEqual) { 'Green' } else { 'Yellow' }
                     Write-Host ("  {0,-52}" -f $display) -NoNewline -ForegroundColor $color
                 }


### PR DESCRIPTION
### Motivation
- Ensure missing landscape values are visible in both console and export output of `Get-DeploymentInfo` by rendering a `-` placeholder instead of leaving blanks so outputs are easier to scan and compare.

### Description
- Update `Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1` to use `'-'` when a landscape value is missing in both the file-export loop and the console `Write-Host` rendering.

### Testing
- Ran the basic PowerShell validation `pwsh -NoProfile -Command "Get-Command ./Scripts/Get-DeploymentInfo/Get-DeploymentInfo.ps1 | Out-Null; 'ok'"` which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a032261d9108333a62d92ad9aca955b)